### PR TITLE
Remove unsupported clear cache properties and change clear storage me…

### DIFF
--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -65,11 +65,10 @@ router.get('/@/:city/:zoom', async (req, res) => {
 
 router.get('/purge', async (req, res) => {
     let target = req.query.target;
-    let type = req.query.type;
     if (!target || !target.startsWith('/')) {
         target = '/';
     }
-    res.set('Clear-Site-Data', `"${type}"`);
+    res.set('Clear-Site-Data', '"cache"');
     res.redirect(target);
 });
 

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -6186,10 +6186,14 @@ function loadFilterSettings (e) {
 }
 
 function clearSiteCache(type) {
+    if (type === 'storage') {
+        localStorage.clear();
+        //return;
+    }
     if (window.location.reload.length == 1) {
         window.location.reload(true);
     } else {
-        window.location.href = '/purge/?target=' + encodeURIComponent(window.location.pathname) + '&type=' + type;
+        window.location.href = '/purge/?target=' + encodeURIComponent(window.location.pathname);
     }
 }
 

--- a/src/views/index.mustache
+++ b/src/views/index.mustache
@@ -653,10 +653,7 @@
                                     {{clear_data}}
                                 </button>
                                 <div class="dropdown-menu">
-                                    <a class="dropdown-item" onclick="clearSiteCache('*');" href="#">{{clear_all_data}}</a>
-                                    <div class="dropdown-divider"></div>
                                     <a class="dropdown-item" onclick="clearSiteCache('cache');" href="#">{{clear_cache}}</a>
-                                    <a class="dropdown-item" onclick="clearSiteCache('cookies');" href="#">{{clear_cookies}}</a>
                                     <a class="dropdown-item" onclick="clearSiteCache('storage');" href="#">{{clear_storage}}</a>
                                 </div>
                             </div>


### PR DESCRIPTION
- Removes unsupported clear cache properties since they don't work on all browsers
- Changes clear storage method to use `localStorage.clear()`

![image](https://user-images.githubusercontent.com/1327440/90948399-4147bd00-e3f3-11ea-9fc2-67d7e9f32227.png)
