### PR TITLE
add default value to fix bug in pokemon filtering

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -7649,6 +7649,7 @@ function registerFilterButtonCallbacks() {
 
 function setPokemonFilters(type, show) {
     const defaultPokemonFilter = {};
+    defaultPokemonFilter['timers-verified'] = { show: false, size: 'normal' };
     for (let i = 1; i <= maxPokemonId; i++) {
         const pkmn = masterfile.pokemon[i];
         const forms = Object.keys(pkmn.forms);


### PR DESCRIPTION
resolves an Uncaught TypeError when one of the categories in “Enable” or “Disable” is clicked in the Pokemon filters menu and the “Verified Despawn Timers” row of the Pokemon filters subsequently tries to lazy load and can't find its entry in pokemonFilterNew.