### PR TITLE
chore: Update package-lock for latest quest_46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1348,7 +1348,7 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pogo-translations": {
-      "version": "git+https://github.com/bschultz/pogo-translations.git#9651fd8cfd115cf01b8d7ce1f7cbb670985a32ea",
+      "version": "git+https://github.com/bschultz/pogo-translations.git#c08d12c3085ed32ee4860529c7e0e55a279ce9f7",
       "from": "git+https://github.com/bschultz/pogo-translations.git"
     },
     "prelude-ls": {


### PR DESCRIPTION
Includes the following three commits so AR-Mapping quests display
properly on the map.
https://github.com/bschultz/pogo-translations/compare/9651fd8cfd115cf01b8d7ce1f7cbb670985a32ea...c08d12c3085ed32ee4860529c7e0e55a279ce9f7