### PR TITLE
Remove blank target object

### DIFF
--- a/src/services/config.js
+++ b/src/services/config.js
@@ -2,14 +2,13 @@
 
 const extend = require('extend');
 const uConfig = require('../configs/config.json');
-const eConfig = require('../configs/default.json');
-const target = {};
+const dConfig = require('../configs/default.json');
 /* 
  * deep Boolean (optional) If set, the merge becomes recursive (i.e. deep copy).
  * target Object The object to extend.
  * object1 Object The object that will be merged into the first.
  * objectN Object (Optional) More objects to merge into the first.
 */
-extend(true, target, eConfig, uConfig);
+extend(true, dConfig, uConfig);
 
-module.exports = target;
+module.exports = dConfig;


### PR DESCRIPTION
If another config file was added, it would not merge properly as written.