### PR TITLE
Allow custom Sessions table

### DIFF
--- a/src/configs/config.example.json
+++ b/src/configs/config.example.json
@@ -31,7 +31,8 @@
             "username": "user",
             "password": "pass123!",
             "database": "rdmdb",
-            "charset": "utf8mb4"
+            "charset": "utf8mb4",
+            "sessionTable": "sessions"
         },
         "manualdb": {
             "host": "127.0.0.1",

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -88,7 +88,8 @@
             "username": "user",
             "password": "pass123!",
             "database": "rdmdb",
-            "charset": "utf8mb4"
+            "charset": "utf8mb4",
+            "sessionTable": "sessions"
         },
         "manualdb": {
             "host": "127.0.0.1",

--- a/src/services/session-store.js
+++ b/src/services/session-store.js
@@ -24,13 +24,17 @@ const sessionStore = new MySQLStore({
     // How frequently expired sessions will be cleared; milliseconds:
     checkExpirationInterval: 900000,
     // Whether or not to create the sessions database table, if one does not already exist
-    createDatabaseTable: true
+    createDatabaseTable: true,
+    // Set Sessions table name
+    schema: {
+        tableName: config.db.scanner.sessionTable
+    }
 });
 
 const isValidSession = async (userId) => {
     let sql = `
     SELECT session_id
-    FROM sessions
+    FROM '${config.db.scanner.sessionTable}'
     WHERE
         json_extract(data, '$.user_id') = ?
         AND expires >= UNIX_TIMESTAMP()
@@ -42,7 +46,7 @@ const isValidSession = async (userId) => {
 
 const clearOtherSessions = async (userId, currentSessionId) => {
     let sql = `
-    DELETE FROM sessions
+    DELETE FROM '${config.db.scanner.sessionTable}'
     WHERE
         json_extract(data, '$.user_id') = ?
         AND session_id != ?


### PR DESCRIPTION
Ran into an issue with multiple pieces of software using the same sessions table.

This allows users to set a custom name for their `sessions` table.

Also defaults to continue using `sessions` if  the user doesn't set something else in their config.