### PR TITLE
Add a way to bypass Discord login from a healthcheck (e.g. for Docker)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ const rateLimitOptions = {
 const requestRateLimiter = rateLimit(rateLimitOptions);
 
 // Healthcheck secret to allow Docker container to bypass Discord redirect
-const HealthcheckSecret = process.env["HEALTHCHECK_SECRET"];
+const HealthcheckSecret = process.env['HEALTHCHECK_SECRET'];
 
 // Basic security protection middleware
 app.use(helmet());
@@ -130,7 +130,7 @@ app.use(async (req, res, next) => {
     if (config.discord.enabled && (req.path === '/api/discord/login' || req.path === '/login')) {
         return next();
     }
-    const healthcheckHeader = req.get("Healthcheck-Secret");
+    const healthcheckHeader = req.get('Healthcheck-Secret');
     const healthcheckValid = healthcheckHeader && healthcheckHeader.length > 0 && healthcheckHeader === HealthcheckSecret;
     if (!config.discord.enabled || healthcheckValid || req.session.logged_in) {
         defaultData.logged_in = true;

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,9 @@ const rateLimitOptions = {
 };
 const requestRateLimiter = rateLimit(rateLimitOptions);
 
+// Healthcheck secret to allow Docker container to bypass Discord redirect
+const HealthcheckSecret = process.env["HEALTHCHECK_SECRET"];
+
 // Basic security protection middleware
 app.use(helmet());
 
@@ -127,10 +130,12 @@ app.use(async (req, res, next) => {
     if (config.discord.enabled && (req.path === '/api/discord/login' || req.path === '/login')) {
         return next();
     }
-    if (!config.discord.enabled || req.session.logged_in) {
+    const healthcheckHeader = req.get("Healthcheck-Secret");
+    const healthcheckValid = healthcheckHeader && healthcheckHeader.length > 0 && healthcheckHeader === HealthcheckSecret;
+    if (!config.discord.enabled || healthcheckValid || req.session.logged_in) {
         defaultData.logged_in = true;
         defaultData.username = req.session.username;
-        if (!config.discord.enabled) {
+        if (!config.discord.enabled || healthcheckValid) {
             return next();
         }
         if (!(await isValidSession(req.session.user_id))) {


### PR DESCRIPTION
When running MapJS in a Docker instance with Discord authentication enabled, there's currently no way of taking advantage of Docker Swarm's `healthcheck` feature because any response from `curl` or `wget` will always be a redirect to the Discord login page. This isn't enough to verify that the map is actually functional. This pull request adds a secure method for Docker to bypass the Discord login and verify that the map itself will return a `200 OK` response within the desired timeout.

In order to bypass the login requirement, a `HEALTHCHECK_SECRET` environment variable must be present for `mapjs`, a `Healthcheck-Secret` header must be present on the request, and the values of each must be identical. This allows for a setup similar to the following in a `docker-compose.yml` file to monitor the status of MapJS and restart it if anything goes wrong:

```yaml
services:
  mapjs:
    # ...
    environment:
      HEALTHCHECK_SECRET: "some_super_secret_value"
    healthcheck:
      test: "curl -fH \"Healthcheck-Secret: $HEALTHCHECK_SECRET\" http://localhost:8080 || exit 1"
      # ...
```

So long as the `HEALTHCHECK_SECRET` value is truly secure and kept safe, this method of bypassing the Discord login requirement will only allow Docker itself to bypass it, and will not allow any end-users to bypass the login requirement.