### PR TITLE
Support Gen 6 Pokemon

### DIFF
--- a/src/data/map.js
+++ b/src/data/map.js
@@ -38,7 +38,16 @@ const getPokemon = async (minLat, maxLat, minLon, maxLon, showPVP, showIV, updat
         } else if (key === 'timers_verified') {
             onlyVerifiedTimersSQL = 'AND expire_timestamp_verified = 1';
         } else {
-            console.warn('Unrecognized key', key);
+            const pokemonId = parseInt(key);
+            if (isNaN(pokemonId)) {
+                console.warn('Unrecognized key', key);
+            } else {
+                pokemonLookup[pokemonId] = false;
+                const defaultForm = (masterfile.pokemon[pokemonId] || {}).default_form_id;
+                if (defaultForm) {
+                    formLookup[defaultForm] = false;
+                }
+            }
         }
     }
 
@@ -65,7 +74,16 @@ const getPokemon = async (minLat, maxLat, minLon, maxLon, showPVP, showIV, updat
             } else if (key === 'or') {
                 orIv = jsFilter;
             } else {
-                console.warn('Unrecognized key', key);
+                const pokemonId = parseInt(key);
+                if (isNaN(pokemonId)) {
+                    console.warn('Unrecognized key', key);
+                } else {
+                    pokemonLookup[pokemonId] = jsFilter;
+                    const defaultForm = (masterfile.pokemon[pokemonId] || {}).default_form_id;
+                    if (defaultForm) {
+                        formLookup[defaultForm] = jsFilter;
+                    }
+                }
             }
         }
     }
@@ -185,9 +203,13 @@ const getGyms = async (minLat, maxLat, minLon, maxLon, updated = 0, showRaids = 
                     }
                 } else {
                     const id = parseInt(key);
-                    if (id) {
+                    if (!isNaN(id)) {
                         if (!excludePokemonIds.includes(id)) {
                             excludePokemonIds.push(id);
+                        }
+                        const defaultForm = (masterfile.pokemon[id] || {}).default_form_id;
+                        if (defaultForm && !excludeFormIds.includes(defaultForm)) {
+                            excludeFormIds.push(defaultForm);
                         }
                     }
                 }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -342,29 +342,27 @@ const getData = async (perms, filter) => {
             'types': null
         });
 
+        let ivLabel = '';
+        if (permShowIV) {
+            ivLabel = `
+                    <label class="btn btn-sm btn-size select-button-new" data-id="${id}" data-type="pokemon" data-info="iv">
+                        <input type="radio" name="options" id="iv" autocomplete="off">${ivString}
+                    </label>
+                    `;
+        }
         for (const [i, pkmn] of Object.entries(masterfile.pokemon)) {
             const forms = Object.keys(pkmn.forms);
             for (let j = 0; j < forms.length; j++) {
                 const formId = forms[j];
-                const types = JSON.stringify(pkmn.types);
+                const form = pkmn.forms[formId];
                 // Grab form from masterfile for consistent language
-                let formName = pkmn.forms[formId].name;
+                let formName = form.name;
                 if (skipForms.includes(formName.toLowerCase())) {
                     // Skip Shadow and Purified forms
                     continue;
                 }
                 formName = formName === 'Normal' ? '' : formName;
                 const id = formId === '0' ? i : i + '-' + formId;
-                let ivLabel = '';
-                if (permShowIV) {
-                    ivLabel = `
-                    <label class="btn btn-sm btn-size select-button-new" data-id="${id}" data-type="pokemon" data-info="iv">
-                        <input type="radio" name="options" id="iv" autocomplete="off">${ivString}
-                    </label>
-                    `;
-                } else {
-                    ivLabel = '';
-                }
                 const filter = generateShowHideButtons(id, 'pokemon', ivLabel);
                 const size = generateSizeButtons(id, 'pokemon');
                 pokemonData.push({
@@ -381,7 +379,7 @@ const getData = async (perms, filter) => {
                     'filter': filter,
                     'size': size,
                     'type': pokemonTypeString,
-                    'types': types
+                    'types': (form.types || pkmn.types || []).join()
                 });
             }
         }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -342,14 +342,6 @@ const getData = async (perms, filter) => {
             'types': null
         });
 
-        let ivLabel = '';
-        if (permShowIV) {
-            ivLabel = `
-                    <label class="btn btn-sm btn-size select-button-new" data-id="${id}" data-type="pokemon" data-info="iv">
-                        <input type="radio" name="options" id="iv" autocomplete="off">${ivString}
-                    </label>
-                    `;
-        }
         for (const [i, pkmn] of Object.entries(masterfile.pokemon)) {
             const forms = Object.keys(pkmn.forms);
             for (let j = 0; j < forms.length; j++) {
@@ -363,6 +355,14 @@ const getData = async (perms, filter) => {
                 }
                 formName = formName === 'Normal' ? '' : formName;
                 const id = formId === '0' ? i : i + '-' + formId;
+                let ivLabel = '';
+                if (permShowIV) {
+                    ivLabel = `
+                    <label class="btn btn-sm btn-size select-button-new" data-id="${id}" data-type="pokemon" data-info="iv">
+                        <input type="radio" name="options" id="iv" autocomplete="off">${ivString}
+                    </label>
+                    `;
+                }
                 const filter = generateShowHideButtons(id, 'pokemon', ivLabel);
                 const size = generateSizeButtons(id, 'pokemon');
                 pokemonData.push({

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -348,7 +348,7 @@ const getData = async (perms, filter) => {
                 const formId = forms[j];
                 const form = pkmn.forms[formId];
                 // Grab form from masterfile for consistent language
-                let formName = form.name;
+                let formName = form.name || '';
                 if (skipForms.includes(formName.toLowerCase())) {
                     // Skip Shadow and Purified forms
                     continue;

--- a/static/data/masterfile.json
+++ b/static/data/masterfile.json
@@ -1497,6 +1497,14 @@
 						"Wild Charge",
 						"Fly"
 					]
+				},
+				"2669": {
+					"name": "Adventure Hat 2020",
+					"proto": "PIKACHU_ADVENTURE_HAT_2020"
+				},
+				"2670": {
+					"name": "Winter 2020",
+					"proto": "PIKACHU_WINTER_2020"
 				}
 			},
 			"default_form_id": 598,
@@ -3962,7 +3970,10 @@
 			"forms": {
 				"310": {
 					"name": "Normal",
-					"proto": "ALAKAZAM_NORMAL"
+					"proto": "ALAKAZAM_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"311": {
 					"name": "Shadow",
@@ -3970,7 +3981,10 @@
 				},
 				"312": {
 					"name": "Purified",
-					"proto": "ALAKAZAM_PURIFIED"
+					"proto": "ALAKAZAM_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 310,
@@ -4001,7 +4015,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 367,
+					"defense": 207,
+					"stamina": 146,
+					"unreleased": true
+				}
+			}
 		},
 		"66": {
 			"name": "Machop",
@@ -4840,12 +4862,14 @@
 			"capture_rate": 0.15,
 			"quick_moves": [
 				"Low Kick",
-				"Fire Spin"
+				"Fire Spin",
+				"Incinerate"
 			],
 			"charged_moves": [
 				"Fire Blast",
 				"Drill Run",
-				"Heat Wave"
+				"Heat Wave",
+				"Flame Charge"
 			],
 			"legendary": false,
 			"mythic": false,
@@ -4942,7 +4966,10 @@
 			"forms": {
 				"1020": {
 					"name": "Normal",
-					"proto": "SLOWBRO_NORMAL"
+					"proto": "SLOWBRO_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1021": {
 					"name": "Shadow",
@@ -4950,7 +4977,10 @@
 				},
 				"1022": {
 					"name": "Purified",
-					"proto": "SLOWBRO_PURIFIED"
+					"proto": "SLOWBRO_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"2583": {
 					"name": "Galarian",
@@ -4985,7 +5015,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 224,
+					"defense": 259,
+					"stamina": 216,
+					"unreleased": true
+				}
+			}
 		},
 		"81": {
 			"name": "Magnemite",
@@ -6972,7 +7010,10 @@
 			"forms": {
 				"839": {
 					"name": "Normal",
-					"proto": "KANGASKHAN_NORMAL"
+					"proto": "KANGASKHAN_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"840": {
 					"name": "Shadow",
@@ -6980,7 +7021,10 @@
 				},
 				"841": {
 					"name": "Purified",
-					"proto": "KANGASKHAN_PURIFIED"
+					"proto": "KANGASKHAN_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 839,
@@ -7011,7 +7055,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 246,
+					"defense": 210,
+					"stamina": 233,
+					"unreleased": true
+				}
+			}
 		},
 		"116": {
 			"name": "Horsea",
@@ -7596,7 +7648,10 @@
 			"forms": {
 				"898": {
 					"name": "Normal",
-					"proto": "PINSIR_NORMAL"
+					"proto": "PINSIR_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"899": {
 					"name": "Shadow",
@@ -7604,7 +7659,10 @@
 				},
 				"900": {
 					"name": "Purified",
-					"proto": "PINSIR_PURIFIED"
+					"proto": "PINSIR_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 898,
@@ -7636,7 +7694,19 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 305,
+					"defense": 231,
+					"stamina": 163,
+					"unreleased": true,
+					"types": [
+						"Bug",
+						"Flying"
+					]
+				}
+			}
 		},
 		"128": {
 			"name": "Tauros",
@@ -7750,7 +7820,10 @@
 			"forms": {
 				"256": {
 					"name": "Normal",
-					"proto": "GYARADOS_NORMAL"
+					"proto": "GYARADOS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"257": {
 					"name": "Shadow",
@@ -7758,7 +7831,10 @@
 				},
 				"258": {
 					"name": "Purified",
-					"proto": "GYARADOS_PURIFIED"
+					"proto": "GYARADOS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 256,
@@ -7791,7 +7867,19 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 292,
+					"defense": 247,
+					"stamina": 216,
+					"unreleased": true,
+					"types": [
+						"Water",
+						"Dark"
+					]
+				}
+			}
 		},
 		"131": {
 			"name": "Lapras",
@@ -8368,7 +8456,10 @@
 			"forms": {
 				"1110": {
 					"name": "Normal",
-					"proto": "AERODACTYL_NORMAL"
+					"proto": "AERODACTYL_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1111": {
 					"name": "Shadow",
@@ -8376,7 +8467,10 @@
 				},
 				"1112": {
 					"name": "Purified",
-					"proto": "AERODACTYL_PURIFIED"
+					"proto": "AERODACTYL_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1110,
@@ -8410,7 +8504,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 292,
+					"defense": 210,
+					"stamina": 190,
+					"unreleased": true
+				}
+			}
 		},
 		"143": {
 			"name": "Snorlax",
@@ -8803,7 +8905,11 @@
 				},
 				"135": {
 					"name": "Normal",
-					"proto": "MEWTWO_NORMAL"
+					"proto": "MEWTWO_NORMAL",
+					"temp_evolutions": {
+						"2": {},
+						"3": {}
+					}
 				},
 				"1113": {
 					"name": "Shadow",
@@ -8811,7 +8917,11 @@
 				},
 				"1114": {
 					"name": "Purified",
-					"proto": "MEWTWO_PURIFIED"
+					"proto": "MEWTWO_PURIFIED",
+					"temp_evolutions": {
+						"2": {},
+						"3": {}
+					}
 				}
 			},
 			"default_form_id": 135,
@@ -8842,7 +8952,25 @@
 			"buddy_group_number": 3,
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
-			"third_move_candy": 100
+			"third_move_candy": 100,
+			"temp_evolutions": {
+				"2": {
+					"attack": 412,
+					"defense": 222,
+					"stamina": 235,
+					"unreleased": true,
+					"types": [
+						"Psychic",
+						"Fighting"
+					]
+				},
+				"3": {
+					"attack": 426,
+					"defense": 229,
+					"stamina": 235,
+					"unreleased": true
+				}
+			}
 		},
 		"151": {
 			"name": "Mew",
@@ -9188,7 +9316,8 @@
 			"capture_rate": 0.05,
 			"quick_moves": [
 				"Ember",
-				"Shadow Claw"
+				"Shadow Claw",
+				"Incinerate"
 			],
 			"charged_moves": [
 				"Fire Blast",
@@ -10332,7 +10461,10 @@
 			"forms": {
 				"652": {
 					"name": "Normal",
-					"proto": "AMPHAROS_NORMAL"
+					"proto": "AMPHAROS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"653": {
 					"name": "Shadow",
@@ -10340,7 +10472,10 @@
 				},
 				"654": {
 					"name": "Purified",
-					"proto": "AMPHAROS_PURIFIED"
+					"proto": "AMPHAROS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 652,
@@ -10372,7 +10507,19 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 294,
+					"defense": 203,
+					"stamina": 207,
+					"unreleased": true,
+					"types": [
+						"Electric",
+						"Dragon"
+					]
+				}
+			}
 		},
 		"182": {
 			"name": "Bellossom",
@@ -11816,7 +11963,10 @@
 			"forms": {
 				"905": {
 					"name": "Normal",
-					"proto": "STEELIX_NORMAL"
+					"proto": "STEELIX_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"906": {
 					"name": "Shadow",
@@ -11824,7 +11974,10 @@
 				},
 				"907": {
 					"name": "Purified",
-					"proto": "STEELIX_PURIFIED"
+					"proto": "STEELIX_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 905,
@@ -11856,7 +12009,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 212,
+					"defense": 327,
+					"stamina": 181,
+					"unreleased": true
+				}
+			}
 		},
 		"209": {
 			"name": "Snubbull",
@@ -12005,7 +12166,10 @@
 			"forms": {
 				"250": {
 					"name": "Normal",
-					"proto": "SCIZOR_NORMAL"
+					"proto": "SCIZOR_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"251": {
 					"name": "Shadow",
@@ -12013,7 +12177,10 @@
 				},
 				"252": {
 					"name": "Purified",
-					"proto": "SCIZOR_PURIFIED"
+					"proto": "SCIZOR_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 250,
@@ -12044,7 +12211,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 279,
+					"defense": 250,
+					"stamina": 172,
+					"unreleased": true
+				}
+			}
 		},
 		"213": {
 			"name": "Shuckle",
@@ -12097,7 +12272,10 @@
 			"forms": {
 				"1262": {
 					"name": "Normal",
-					"proto": "HERACROSS_NORMAL"
+					"proto": "HERACROSS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1263": {
 					"name": "Shadow",
@@ -12105,7 +12283,10 @@
 				},
 				"1264": {
 					"name": "Purified",
-					"proto": "HERACROSS_PURIFIED"
+					"proto": "HERACROSS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1262,
@@ -12136,7 +12317,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 334,
+					"defense": 223,
+					"stamina": 190,
+					"unreleased": true
+				}
+			}
 		},
 		"215": {
 			"name": "Sneasel",
@@ -12666,6 +12855,10 @@
 				"940": {
 					"name": "Purified",
 					"proto": "DELIBIRD_PURIFIED"
+				},
+				"2671": {
+					"name": "Winter 2020",
+					"proto": "DELIBIRD_WINTER_2020"
 				}
 			},
 			"default_form_id": 938,
@@ -13619,7 +13812,8 @@
 				"Flamethrower",
 				"Fire Blast",
 				"Overheat",
-				"Iron Head"
+				"Iron Head",
+				"Flame Charge"
 			],
 			"legendary": true,
 			"mythic": false,
@@ -13811,7 +14005,10 @@
 			"forms": {
 				"319": {
 					"name": "Normal",
-					"proto": "TYRANITAR_NORMAL"
+					"proto": "TYRANITAR_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"320": {
 					"name": "Shadow",
@@ -13819,7 +14016,10 @@
 				},
 				"321": {
 					"name": "Purified",
-					"proto": "TYRANITAR_PURIFIED"
+					"proto": "TYRANITAR_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 319,
@@ -13850,7 +14050,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 309,
+					"defense": 276,
+					"stamina": 225,
+					"unreleased": true
+				}
+			}
 		},
 		"249": {
 			"name": "Lugia",
@@ -13929,7 +14137,8 @@
 			"quick_moves": [
 				"Extrasensory",
 				"Steel Wing",
-				"Hidden Power"
+				"Hidden Power",
+				"Incinerate"
 			],
 			"charged_moves": [
 				"Brave Bird",
@@ -14089,7 +14298,10 @@
 			"forms": {
 				"1355": {
 					"name": "Normal",
-					"proto": "SCEPTILE_NORMAL"
+					"proto": "SCEPTILE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1356": {
 					"name": "Shadow",
@@ -14097,7 +14309,10 @@
 				},
 				"1357": {
 					"name": "Purified",
-					"proto": "SCEPTILE_PURIFIED"
+					"proto": "SCEPTILE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1355,
@@ -14128,7 +14343,19 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 320,
+					"defense": 186,
+					"stamina": 172,
+					"unreleased": true,
+					"types": [
+						"Grass",
+						"Dragon"
+					]
+				}
+			}
 		},
 		"255": {
 			"name": "Torchic",
@@ -14232,7 +14459,10 @@
 			"forms": {
 				"1364": {
 					"name": "Normal",
-					"proto": "BLAZIKEN_NORMAL"
+					"proto": "BLAZIKEN_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1365": {
 					"name": "Shadow",
@@ -14240,7 +14470,10 @@
 				},
 				"1366": {
 					"name": "Purified",
-					"proto": "BLAZIKEN_PURIFIED"
+					"proto": "BLAZIKEN_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1364,
@@ -14272,7 +14505,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 329,
+					"defense": 168,
+					"stamina": 190,
+					"unreleased": true
+				}
+			}
 		},
 		"258": {
 			"name": "Mudkip",
@@ -14410,7 +14651,10 @@
 			"forms": {
 				"211": {
 					"name": "Normal",
-					"proto": "SWAMPERT_NORMAL"
+					"proto": "SWAMPERT_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"212": {
 					"name": "Shadow",
@@ -14418,7 +14662,10 @@
 				},
 				"213": {
 					"name": "Purified",
-					"proto": "SWAMPERT_PURIFIED"
+					"proto": "SWAMPERT_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 211,
@@ -14450,7 +14697,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 283,
+					"defense": 218,
+					"stamina": 225,
+					"unreleased": true
+				}
+			}
 		},
 		"261": {
 			"name": "Poochyena",
@@ -15602,7 +15857,10 @@
 			"forms": {
 				"298": {
 					"name": "Normal",
-					"proto": "GARDEVOIR_NORMAL"
+					"proto": "GARDEVOIR_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"299": {
 					"name": "Shadow",
@@ -15610,7 +15868,10 @@
 				},
 				"300": {
 					"name": "Purified",
-					"proto": "GARDEVOIR_PURIFIED"
+					"proto": "GARDEVOIR_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 298,
@@ -15642,7 +15903,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 326,
+					"defense": 229,
+					"stamina": 169,
+					"unreleased": true
+				}
+			}
 		},
 		"283": {
 			"name": "Surskit",
@@ -16546,7 +16815,10 @@
 			"forms": {
 				"923": {
 					"name": "Normal",
-					"proto": "SABLEYE_NORMAL"
+					"proto": "SABLEYE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"924": {
 					"name": "Shadow",
@@ -16554,7 +16826,10 @@
 				},
 				"925": {
 					"name": "Purified",
-					"proto": "SABLEYE_PURIFIED"
+					"proto": "SABLEYE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"2666": {
 					"name": "Costume 2020 Deprecated",
@@ -16593,14 +16868,25 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 151,
+					"defense": 216,
+					"stamina": 137,
+					"unreleased": true
+				}
+			}
 		},
 		"303": {
 			"name": "Mawile",
 			"forms": {
 				"833": {
 					"name": "Normal",
-					"proto": "MAWILE_NORMAL"
+					"proto": "MAWILE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"834": {
 					"name": "Shadow",
@@ -16608,7 +16894,10 @@
 				},
 				"835": {
 					"name": "Purified",
-					"proto": "MAWILE_PURIFIED"
+					"proto": "MAWILE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 833,
@@ -16642,7 +16931,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 188,
+					"defense": 217,
+					"stamina": 137,
+					"unreleased": true
+				}
+			}
 		},
 		"304": {
 			"name": "Aron",
@@ -16747,7 +17044,10 @@
 			"forms": {
 				"1475": {
 					"name": "Normal",
-					"proto": "AGGRON_NORMAL"
+					"proto": "AGGRON_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1476": {
 					"name": "Shadow",
@@ -16755,7 +17055,10 @@
 				},
 				"1477": {
 					"name": "Purified",
-					"proto": "AGGRON_PURIFIED"
+					"proto": "AGGRON_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1475,
@@ -16787,7 +17090,18 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 247,
+					"defense": 331,
+					"stamina": 172,
+					"unreleased": true,
+					"types": [
+						"Steel"
+					]
+				}
+			}
 		},
 		"307": {
 			"name": "Meditite",
@@ -16843,7 +17157,10 @@
 			"forms": {
 				"1481": {
 					"name": "Normal",
-					"proto": "MEDICHAM_NORMAL"
+					"proto": "MEDICHAM_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1482": {
 					"name": "Shadow",
@@ -16851,7 +17168,10 @@
 				},
 				"1483": {
 					"name": "Purified",
-					"proto": "MEDICHAM_PURIFIED"
+					"proto": "MEDICHAM_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1481,
@@ -16883,7 +17203,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 205,
+					"defense": 179,
+					"stamina": 155,
+					"unreleased": true
+				}
+			}
 		},
 		"309": {
 			"name": "Electrike",
@@ -16938,7 +17266,10 @@
 			"forms": {
 				"1487": {
 					"name": "Normal",
-					"proto": "MANECTRIC_NORMAL"
+					"proto": "MANECTRIC_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1488": {
 					"name": "Shadow",
@@ -16946,7 +17277,10 @@
 				},
 				"1489": {
 					"name": "Purified",
-					"proto": "MANECTRIC_PURIFIED"
+					"proto": "MANECTRIC_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1487,
@@ -16976,7 +17310,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 286,
+					"defense": 179,
+					"stamina": 172,
+					"unreleased": true
+				}
+			}
 		},
 		"311": {
 			"name": "Plusle",
@@ -17374,7 +17716,10 @@
 			"forms": {
 				"737": {
 					"name": "Normal",
-					"proto": "SHARPEDO_NORMAL"
+					"proto": "SHARPEDO_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"738": {
 					"name": "Shadow",
@@ -17382,7 +17727,10 @@
 				},
 				"739": {
 					"name": "Purified",
-					"proto": "SHARPEDO_PURIFIED"
+					"proto": "SHARPEDO_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 737,
@@ -17413,7 +17761,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 289,
+					"defense": 144,
+					"stamina": 172,
+					"unreleased": true
+				}
+			}
 		},
 		"320": {
 			"name": "Wailmer",
@@ -17562,7 +17918,10 @@
 			"forms": {
 				"1520": {
 					"name": "Normal",
-					"proto": "CAMERUPT_NORMAL"
+					"proto": "CAMERUPT_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1521": {
 					"name": "Shadow",
@@ -17570,7 +17929,10 @@
 				},
 				"1522": {
 					"name": "Purified",
-					"proto": "CAMERUPT_PURIFIED"
+					"proto": "CAMERUPT_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1520,
@@ -17602,7 +17964,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 253,
+					"defense": 183,
+					"stamina": 172,
+					"unreleased": true
+				}
+			}
 		},
 		"324": {
 			"name": "Torkoal",
@@ -18197,7 +18567,10 @@
 			"forms": {
 				"1535": {
 					"name": "Normal",
-					"proto": "ALTARIA_NORMAL"
+					"proto": "ALTARIA_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1536": {
 					"name": "Shadow",
@@ -18205,7 +18578,10 @@
 				},
 				"1537": {
 					"name": "Purified",
-					"proto": "ALTARIA_PURIFIED"
+					"proto": "ALTARIA_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1535,
@@ -18236,7 +18612,19 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 222,
+					"defense": 218,
+					"stamina": 181,
+					"unreleased": true,
+					"types": [
+						"Dragon",
+						"Fairy"
+					]
+				}
+			}
 		},
 		"335": {
 			"name": "Zangoose",
@@ -19196,7 +19584,10 @@
 			"forms": {
 				"911": {
 					"name": "Normal",
-					"proto": "BANETTE_NORMAL"
+					"proto": "BANETTE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"912": {
 					"name": "Shadow",
@@ -19204,7 +19595,10 @@
 				},
 				"913": {
 					"name": "Purified",
-					"proto": "BANETTE_PURIFIED"
+					"proto": "BANETTE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 911,
@@ -19234,7 +19628,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 312,
+					"defense": 160,
+					"stamina": 162,
+					"unreleased": true
+				}
+			}
 		},
 		"355": {
 			"name": "Duskull",
@@ -19463,7 +19865,10 @@
 			"forms": {
 				"830": {
 					"name": "Normal",
-					"proto": "ABSOL_NORMAL"
+					"proto": "ABSOL_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"831": {
 					"name": "Shadow",
@@ -19471,7 +19876,10 @@
 				},
 				"832": {
 					"name": "Purified",
-					"proto": "ABSOL_PURIFIED"
+					"proto": "ABSOL_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 830,
@@ -19501,7 +19909,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 314,
+					"defense": 130,
+					"stamina": 163,
+					"unreleased": true
+				}
+			}
 		},
 		"360": {
 			"name": "Wynaut",
@@ -19605,7 +20021,10 @@
 			"forms": {
 				"929": {
 					"name": "Normal",
-					"proto": "GLALIE_NORMAL"
+					"proto": "GLALIE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"930": {
 					"name": "Shadow",
@@ -19613,7 +20032,10 @@
 				},
 				"931": {
 					"name": "Purified",
-					"proto": "GLALIE_PURIFIED"
+					"proto": "GLALIE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 929,
@@ -19643,7 +20065,15 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 252,
+					"defense": 168,
+					"stamina": 190,
+					"unreleased": true
+				}
+			}
 		},
 		"363": {
 			"name": "Spheal",
@@ -20153,7 +20583,10 @@
 			"forms": {
 				"761": {
 					"name": "Normal",
-					"proto": "SALAMENCE_NORMAL"
+					"proto": "SALAMENCE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"762": {
 					"name": "Shadow",
@@ -20161,7 +20594,10 @@
 				},
 				"763": {
 					"name": "Purified",
-					"proto": "SALAMENCE_PURIFIED"
+					"proto": "SALAMENCE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 761,
@@ -20193,7 +20629,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 310,
+					"defense": 251,
+					"stamina": 216,
+					"unreleased": true
+				}
+			}
 		},
 		"374": {
 			"name": "Beldum",
@@ -20327,7 +20771,10 @@
 			"forms": {
 				"770": {
 					"name": "Normal",
-					"proto": "METAGROSS_NORMAL"
+					"proto": "METAGROSS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"771": {
 					"name": "Shadow",
@@ -20335,7 +20782,10 @@
 				},
 				"772": {
 					"name": "Purified",
-					"proto": "METAGROSS_PURIFIED"
+					"proto": "METAGROSS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 770,
@@ -20366,7 +20816,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 300,
+					"defense": 289,
+					"stamina": 190,
+					"unreleased": true
+				}
+			}
 		},
 		"377": {
 			"name": "Regirock",
@@ -20508,7 +20966,10 @@
 			"forms": {
 				"1631": {
 					"name": "Normal",
-					"proto": "LATIAS_NORMAL"
+					"proto": "LATIAS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1632": {
 					"name": "Shadow",
@@ -20516,7 +20977,10 @@
 				},
 				"1633": {
 					"name": "Purified",
-					"proto": "LATIAS_PURIFIED"
+					"proto": "LATIAS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1631,
@@ -20547,14 +21011,25 @@
 			"buddy_group_number": 7,
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
-			"third_move_candy": 100
+			"third_move_candy": 100,
+			"temp_evolutions": {
+				"1": {
+					"attack": 289,
+					"defense": 297,
+					"stamina": 190,
+					"unreleased": true
+				}
+			}
 		},
 		"381": {
 			"name": "Latios",
 			"forms": {
 				"1634": {
 					"name": "Normal",
-					"proto": "LATIOS_NORMAL"
+					"proto": "LATIOS_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1635": {
 					"name": "Shadow",
@@ -20562,7 +21037,10 @@
 				},
 				"1636": {
 					"name": "Purified",
-					"proto": "LATIOS_PURIFIED"
+					"proto": "LATIOS_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1634,
@@ -20592,7 +21070,15 @@
 			"buddy_group_number": 7,
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
-			"third_move_candy": 100
+			"third_move_candy": 100,
+			"temp_evolutions": {
+				"1": {
+					"attack": 335,
+					"defense": 241,
+					"stamina": 190,
+					"unreleased": true
+				}
+			}
 		},
 		"382": {
 			"name": "Kyogre",
@@ -20687,7 +21173,10 @@
 			"forms": {
 				"1643": {
 					"name": "Normal",
-					"proto": "RAYQUAZA_NORMAL"
+					"proto": "RAYQUAZA_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1644": {
 					"name": "Shadow",
@@ -20695,7 +21184,10 @@
 				},
 				"1645": {
 					"name": "Purified",
-					"proto": "RAYQUAZA_PURIFIED"
+					"proto": "RAYQUAZA_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1643,
@@ -20725,7 +21217,15 @@
 			"buddy_group_number": 7,
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
-			"third_move_candy": 100
+			"third_move_candy": 100,
+			"temp_evolutions": {
+				"1": {
+					"attack": 389,
+					"defense": 216,
+					"stamina": 233,
+					"unreleased": true
+				}
+			}
 		},
 		"385": {
 			"name": "Jirachi",
@@ -22996,7 +23496,10 @@
 			"forms": {
 				"1754": {
 					"name": "Normal",
-					"proto": "LOPUNNY_NORMAL"
+					"proto": "LOPUNNY_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1755": {
 					"name": "Shadow",
@@ -23004,7 +23507,10 @@
 				},
 				"1756": {
 					"name": "Purified",
-					"proto": "LOPUNNY_PURIFIED"
+					"proto": "LOPUNNY_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1754,
@@ -23034,7 +23540,19 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 282,
+					"defense": 214,
+					"stamina": 163,
+					"unreleased": true,
+					"types": [
+						"Normal",
+						"Fighting"
+					]
+				}
+			}
 		},
 		"429": {
 			"name": "Mismagius",
@@ -23850,7 +24368,10 @@
 			"forms": {
 				"867": {
 					"name": "Normal",
-					"proto": "GARCHOMP_NORMAL"
+					"proto": "GARCHOMP_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"868": {
 					"name": "Shadow",
@@ -23858,7 +24379,10 @@
 				},
 				"869": {
 					"name": "Purified",
-					"proto": "GARCHOMP_PURIFIED"
+					"proto": "GARCHOMP_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 867,
@@ -23890,7 +24414,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 339,
+					"defense": 222,
+					"stamina": 239,
+					"unreleased": true
+				}
+			}
 		},
 		"446": {
 			"name": "Munchlax",
@@ -23992,7 +24524,10 @@
 			"forms": {
 				"1793": {
 					"name": "Normal",
-					"proto": "LUCARIO_NORMAL"
+					"proto": "LUCARIO_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1794": {
 					"name": "Shadow",
@@ -24000,7 +24535,10 @@
 				},
 				"1795": {
 					"name": "Purified",
-					"proto": "LUCARIO_PURIFIED"
+					"proto": "LUCARIO_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1793,
@@ -24033,7 +24571,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 310,
+					"defense": 175,
+					"stamina": 172,
+					"unreleased": true
+				}
+			}
 		},
 		"449": {
 			"name": "Hippopotas",
@@ -24599,7 +25145,10 @@
 			"forms": {
 				"935": {
 					"name": "Normal",
-					"proto": "ABOMASNOW_NORMAL"
+					"proto": "ABOMASNOW_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"936": {
 					"name": "Shadow",
@@ -24607,7 +25156,10 @@
 				},
 				"937": {
 					"name": "Purified",
-					"proto": "ABOMASNOW_PURIFIED"
+					"proto": "ABOMASNOW_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 935,
@@ -24633,6 +25185,15 @@
 				"Outrage",
 				"Weather Ball"
 			],
+			"temp_evolutions": {
+				"1": {
+					"attack": 240,
+					"defense": 191,
+					"stamina": 207,
+					"height": 2.7,
+					"weight": 185
+				}
+			},
 			"legendary": false,
 			"mythic": false,
 			"buddy_group_number": 2,
@@ -25297,7 +25858,10 @@
 			"forms": {
 				"301": {
 					"name": "Normal",
-					"proto": "GALLADE_NORMAL"
+					"proto": "GALLADE_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"302": {
 					"name": "Shadow",
@@ -25305,7 +25869,10 @@
 				},
 				"303": {
 					"name": "Purified",
-					"proto": "GALLADE_PURIFIED"
+					"proto": "GALLADE_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 301,
@@ -25337,7 +25904,15 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 326,
+					"defense": 230,
+					"stamina": 169,
+					"unreleased": true
+				}
+			}
 		},
 		"476": {
 			"name": "Probopass",
@@ -26671,7 +27246,8 @@
 			"charged_moves": [
 				"Heat Wave",
 				"Rock Slide",
-				"Focus Blast"
+				"Focus Blast",
+				"Flame Charge"
 			],
 			"legendary": false,
 			"mythic": false,
@@ -28096,7 +28672,10 @@
 			"forms": {
 				"1997": {
 					"name": "Normal",
-					"proto": "AUDINO_NORMAL"
+					"proto": "AUDINO_NORMAL",
+					"temp_evolutions": {
+						"1": {}
+					}
 				},
 				"1998": {
 					"name": "Shadow",
@@ -28104,7 +28683,10 @@
 				},
 				"1999": {
 					"name": "Purified",
-					"proto": "AUDINO_PURIFIED"
+					"proto": "AUDINO_PURIFIED",
+					"temp_evolutions": {
+						"1": {}
+					}
 				}
 			},
 			"default_form_id": 1997,
@@ -28134,7 +28716,19 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"temp_evolutions": {
+				"1": {
+					"attack": 147,
+					"defense": 239,
+					"stamina": 230,
+					"unreleased": true,
+					"types": [
+						"Normal",
+						"Fairy"
+					]
+				}
+			}
 		},
 		"532": {
 			"name": "Timburr",
@@ -29322,7 +29916,8 @@
 			"capture_rate": 0.1,
 			"quick_moves": [
 				"Tackle",
-				"Fire Fang"
+				"Fire Fang",
+				"Incinerate"
 			],
 			"charged_moves": [
 				"Overheat",
@@ -31952,12 +32547,14 @@
 			"capture_rate": 0.05,
 			"quick_moves": [
 				"Hex",
-				"Fire Spin"
+				"Fire Spin",
+				"Incinerate"
 			],
 			"charged_moves": [
 				"Energy Ball",
 				"Shadow Ball",
-				"Overheat"
+				"Overheat",
+				"Flame Charge"
 			],
 			"legendary": false,
 			"mythic": false,
@@ -32123,6 +32720,10 @@
 				"2233": {
 					"name": "Purified",
 					"proto": "CUBCHOO_PURIFIED"
+				},
+				"2672": {
+					"name": "Winter 2020",
+					"proto": "CUBCHOO_WINTER_2020"
 				}
 			},
 			"default_form_id": 2231,
@@ -33908,6 +34509,2701 @@
 			"third_move_stardust": 100000,
 			"third_move_candy": 100
 		},
+		"650": {
+			"name": "Chespin",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 650,
+			"types": [
+				"Grass"
+			],
+			"attack": 110,
+			"defense": 106,
+			"stamina": 148,
+			"height": 0.4,
+			"weight": 9,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Take Down",
+				"Vine Whip"
+			],
+			"charged_moves": [
+				"Gyro Ball",
+				"Seed Bomb",
+				"Body Slam"
+			],
+			"evolutions": {
+				"651": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 1,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"651": {
+			"name": "Quilladin",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 651,
+			"types": [
+				"Grass"
+			],
+			"attack": 146,
+			"defense": 156,
+			"stamina": 156,
+			"height": 0.7,
+			"weight": 29,
+			"flee_rate": 0.1,
+			"capture_rate": 0.1,
+			"quick_moves": [
+				"Low Kick",
+				"Razor Leaf"
+			],
+			"charged_moves": [
+				"Gyro Ball",
+				"Energy Ball",
+				"Body Slam"
+			],
+			"evolutions": {
+				"652": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 2,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"652": {
+			"name": "Chesnaught",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 652,
+			"types": [
+				"Grass",
+				"Fighting"
+			],
+			"attack": 201,
+			"defense": 204,
+			"stamina": 204,
+			"height": 1.6,
+			"weight": 90,
+			"flee_rate": 0.1,
+			"capture_rate": 0.05,
+			"quick_moves": [
+				"Low Kick",
+				"Razor Leaf",
+				"Vine Whip"
+			],
+			"charged_moves": [
+				"Gyro Ball",
+				"Energy Ball",
+				"Super Power",
+				"Solar Beam"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 3,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"653": {
+			"name": "Fennekin",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 653,
+			"types": [
+				"Fire"
+			],
+			"attack": 116,
+			"defense": 102,
+			"stamina": 120,
+			"height": 0.4,
+			"weight": 9.4,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Scratch",
+				"Ember"
+			],
+			"charged_moves": [
+				"Psyshock",
+				"Flamethrower",
+				"Flame Charge"
+			],
+			"evolutions": {
+				"654": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 1,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"654": {
+			"name": "Braixen",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 654,
+			"types": [
+				"Fire"
+			],
+			"attack": 171,
+			"defense": 130,
+			"stamina": 153,
+			"height": 1,
+			"weight": 14.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.1,
+			"quick_moves": [
+				"Scratch",
+				"Ember"
+			],
+			"charged_moves": [
+				"Psyshock",
+				"Flamethrower",
+				"Flame Charge"
+			],
+			"evolutions": {
+				"655": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 2,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"655": {
+			"name": "Delphox",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 655,
+			"types": [
+				"Fire",
+				"Psychic"
+			],
+			"attack": 230,
+			"defense": 189,
+			"stamina": 181,
+			"height": 1.5,
+			"weight": 39,
+			"flee_rate": 0.1,
+			"capture_rate": 0.05,
+			"quick_moves": [
+				"Scratch",
+				"Fire Spin",
+				"Zen Headbutt"
+			],
+			"charged_moves": [
+				"Psychic",
+				"Flamethrower",
+				"Flame Charge",
+				"Fire Blast"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 3,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"656": {
+			"name": "Froakie",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 656,
+			"types": [
+				"Water"
+			],
+			"attack": 122,
+			"defense": 84,
+			"stamina": 121,
+			"height": 0.3,
+			"weight": 7,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Pound",
+				"Bubble"
+			],
+			"charged_moves": [
+				"Water Pulse",
+				"Aerial Ace",
+				"Surf"
+			],
+			"evolutions": {
+				"657": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 1,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"657": {
+			"name": "Frogadier",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 657,
+			"types": [
+				"Water"
+			],
+			"attack": 168,
+			"defense": 114,
+			"stamina": 144,
+			"height": 0.6,
+			"weight": 10.9,
+			"flee_rate": 0.1,
+			"capture_rate": 0.1,
+			"quick_moves": [
+				"Pound",
+				"Bubble"
+			],
+			"charged_moves": [
+				"Night Slash",
+				"Aerial Ace",
+				"Surf"
+			],
+			"evolutions": {
+				"658": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 2,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"658": {
+			"name": "Greninja",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 658,
+			"types": [
+				"Water",
+				"Dark"
+			],
+			"attack": 223,
+			"defense": 152,
+			"stamina": 176,
+			"height": 1.5,
+			"weight": 40,
+			"flee_rate": 0.1,
+			"capture_rate": 0.05,
+			"quick_moves": [
+				"Feint Attack",
+				"Bubble"
+			],
+			"charged_moves": [
+				"Night Slash",
+				"Aerial Ace",
+				"Surf",
+				"Hydro Pump"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 3,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"659": {
+			"name": "Bunnelby",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 659,
+			"types": [
+				"Normal"
+			],
+			"attack": 68,
+			"defense": 72,
+			"stamina": 116,
+			"height": 0.4,
+			"weight": 5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Mud Slap",
+				"Quick Attack"
+			],
+			"charged_moves": [
+				"Dig",
+				"Bulldoze",
+				"Earthquake"
+			],
+			"evolutions": {
+				"660": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 2,
+			"buddy_distance": 1,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"660": {
+			"name": "Diggersby",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 660,
+			"types": [
+				"Normal",
+				"Ground"
+			],
+			"attack": 112,
+			"defense": 155,
+			"stamina": 198,
+			"height": 1,
+			"weight": 42.4,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Mud Shot",
+				"Quick Attack"
+			],
+			"charged_moves": [
+				"Dig",
+				"Hyper Beam",
+				"Earthquake",
+				"Fire Punch"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 3,
+			"buddy_distance": 1,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"661": {
+			"name": "Fletchling",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 661,
+			"types": [
+				"Normal",
+				"Flying"
+			],
+			"attack": 95,
+			"defense": 80,
+			"stamina": 128,
+			"height": 0.3,
+			"weight": 1.7,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Peck",
+				"Quick Attack"
+			],
+			"charged_moves": [
+				"Aerial Ace",
+				"Heat Wave",
+				"Swift"
+			],
+			"evolutions": {
+				"662": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 4,
+			"buddy_distance": 1,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"662": {
+			"name": "Fletchinder",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 662,
+			"types": [
+				"Fire",
+				"Flying"
+			],
+			"attack": 145,
+			"defense": 110,
+			"stamina": 158,
+			"height": 0.7,
+			"weight": 16,
+			"flee_rate": 0.1,
+			"capture_rate": 0.1,
+			"quick_moves": [
+				"Peck",
+				"Ember",
+				"Steel Wing"
+			],
+			"charged_moves": [
+				"Aerial Ace",
+				"Heat Wave",
+				"Flame Charge"
+			],
+			"evolutions": {
+				"663": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 4,
+			"buddy_distance": 1,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"663": {
+			"name": "Talonflame",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 663,
+			"types": [
+				"Fire",
+				"Flying"
+			],
+			"attack": 176,
+			"defense": 155,
+			"stamina": 186,
+			"height": 1.2,
+			"weight": 24.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.05,
+			"quick_moves": [
+				"Peck",
+				"Fire Spin",
+				"Steel Wing"
+			],
+			"charged_moves": [
+				"Brave Bird",
+				"Fire Blast",
+				"Flame Charge",
+				"Hurricane"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 5,
+			"buddy_distance": 1,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"664": {
+			"name": "Scatterbug",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 664,
+			"types": [
+				"Bug"
+			],
+			"attack": 63,
+			"defense": 63,
+			"stamina": 116,
+			"height": 0.3,
+			"weight": 2.5,
+			"flee_rate": 0.2,
+			"capture_rate": 0.5,
+			"quick_moves": [
+				"Bug Bite",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Struggle"
+			],
+			"evolutions": {
+				"665": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 1,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"665": {
+			"name": "Spewpa",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 665,
+			"types": [
+				"Bug"
+			],
+			"attack": 48,
+			"defense": 89,
+			"stamina": 128,
+			"height": 0.3,
+			"weight": 8.4,
+			"flee_rate": 0.09,
+			"capture_rate": 0.25,
+			"quick_moves": [
+				"Bug Bite",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Struggle"
+			],
+			"evolutions": {
+				"666": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 1,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"666": {
+			"name": "Vivillon",
+			"forms": {
+				"2594": {
+					"name": "Archipelago",
+					"proto": "VIVILLON_ARCHIPELAGO"
+				},
+				"2595": {
+					"name": "Continental",
+					"proto": "VIVILLON_CONTINENTAL"
+				},
+				"2596": {
+					"name": "Elegant",
+					"proto": "VIVILLON_ELEGANT"
+				},
+				"2597": {
+					"name": "Fancy",
+					"proto": "VIVILLON_FANCY"
+				},
+				"2598": {
+					"name": "Garden",
+					"proto": "VIVILLON_GARDEN"
+				},
+				"2599": {
+					"name": "High Plains",
+					"proto": "VIVILLON_HIGH_PLAINS"
+				},
+				"2600": {
+					"name": "Icy Snow",
+					"proto": "VIVILLON_ICY_SNOW"
+				},
+				"2601": {
+					"name": "Jungle",
+					"proto": "VIVILLON_JUNGLE"
+				},
+				"2602": {
+					"name": "Marine",
+					"proto": "VIVILLON_MARINE"
+				},
+				"2603": {
+					"name": "Meadow",
+					"proto": "VIVILLON_MEADOW"
+				},
+				"2604": {
+					"name": "Modern",
+					"proto": "VIVILLON_MODERN"
+				},
+				"2605": {
+					"name": "Monsoon",
+					"proto": "VIVILLON_MONSOON"
+				},
+				"2606": {
+					"name": "Ocean",
+					"proto": "VIVILLON_OCEAN"
+				},
+				"2607": {
+					"name": "Pokeball",
+					"proto": "VIVILLON_POKEBALL"
+				},
+				"2608": {
+					"name": "Polar",
+					"proto": "VIVILLON_POLAR"
+				},
+				"2609": {
+					"name": "River",
+					"proto": "VIVILLON_RIVER"
+				},
+				"2610": {
+					"name": "Sandstorm",
+					"proto": "VIVILLON_SANDSTORM"
+				},
+				"2611": {
+					"name": "Savanna",
+					"proto": "VIVILLON_SAVANNA"
+				},
+				"2612": {
+					"name": "Sun",
+					"proto": "VIVILLON_SUN"
+				},
+				"2613": {
+					"name": "Tundra",
+					"proto": "VIVILLON_TUNDRA"
+				}
+			},
+			"pokedex_id": 666,
+			"types": [
+				"Bug",
+				"Flying"
+			],
+			"attack": 176,
+			"defense": 103,
+			"stamina": 190,
+			"height": 1.2,
+			"weight": 17,
+			"flee_rate": 0.06,
+			"capture_rate": 0.125,
+			"quick_moves": [
+				"Bug Bite",
+				"Gust",
+				"Struggle Bug"
+			],
+			"charged_moves": [
+				"Bug Buzz",
+				"Aerial Ace",
+				"Energy Ball",
+				"Hurricane"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 1,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"667": {
+			"name": "Litleo",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 667,
+			"types": [
+				"Fire",
+				"Normal"
+			],
+			"attack": 139,
+			"defense": 112,
+			"stamina": 158,
+			"height": 0.6,
+			"weight": 13.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.3,
+			"quick_moves": [
+				"Fire Fang",
+				"Tackle",
+				"Ember"
+			],
+			"charged_moves": [
+				"Flame Charge",
+				"Flamethrower",
+				"Crunch"
+			],
+			"evolutions": {
+				"668": {
+					"form": 2588,
+					"gender_requirement": 2
+				}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 1,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"668": {
+			"name": "Pyroar",
+			"forms": {
+				"2587": {
+					"name": "Normal",
+					"proto": "PYROAR_NORMAL",
+					"quick_moves": [
+						"Fire Fang",
+						"Take Down"
+					]
+				},
+				"2588": {
+					"name": "Female",
+					"proto": "PYROAR_FEMALE",
+					"quick_moves": [
+						"Fire Fang",
+						"Take Down"
+					]
+				}
+			},
+			"default_form_id": 2587,
+			"pokedex_id": 668,
+			"types": [
+				"Fire",
+				"Normal"
+			],
+			"attack": 221,
+			"defense": 149,
+			"stamina": 200,
+			"height": 1.5,
+			"weight": 81.5,
+			"flee_rate": 0.07,
+			"capture_rate": 0.1,
+			"quick_moves": [
+				"Fire Fang",
+				"Take Down",
+				"Ember"
+			],
+			"charged_moves": [
+				"Flame Charge",
+				"Solar Beam",
+				"Dark Pulse",
+				"Overheat"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 10000,
+			"third_move_candy": 25,
+			"gym_defender_eligible": true
+		},
+		"669": {
+			"name": "Flabebe",
+			"forms": {
+				"2614": {
+					"name": "Red",
+					"proto": "FLABEBE_RED"
+				},
+				"2615": {
+					"name": "Yellow",
+					"proto": "FLABEBE_YELLOW"
+				},
+				"2616": {
+					"name": "Orange",
+					"proto": "FLABEBE_ORANGE"
+				},
+				"2617": {
+					"name": "Blue",
+					"proto": "FLABEBE_BLUE"
+				},
+				"2618": {
+					"name": "White",
+					"proto": "FLABEBE_WHITE"
+				}
+			},
+			"pokedex_id": 669,
+			"types": [
+				"Fairy"
+			],
+			"attack": 108,
+			"defense": 120,
+			"stamina": 127,
+			"height": 0.1,
+			"weight": 0.1,
+			"flee_rate": 0.15,
+			"capture_rate": 0.5,
+			"quick_moves": [
+				"Vine Whip",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Dazzling Gleam",
+				"Petal Blizzard",
+				"Psychic"
+			],
+			"evolutions": {
+				"670": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"670": {
+			"name": "Floette",
+			"forms": {
+				"2619": {
+					"name": "Red",
+					"proto": "FLOETTE_RED"
+				},
+				"2620": {
+					"name": "Yellow",
+					"proto": "FLOETTE_YELLOW"
+				},
+				"2621": {
+					"name": "Orange",
+					"proto": "FLOETTE_ORANGE"
+				},
+				"2622": {
+					"name": "Blue",
+					"proto": "FLOETTE_BLUE"
+				},
+				"2623": {
+					"name": "White",
+					"proto": "FLOETTE_WHITE"
+				}
+			},
+			"pokedex_id": 670,
+			"types": [
+				"Fairy"
+			],
+			"attack": 136,
+			"defense": 151,
+			"stamina": 144,
+			"height": 0.2,
+			"weight": 0.9,
+			"flee_rate": 0.07,
+			"capture_rate": 0.25,
+			"quick_moves": [
+				"Vine Whip",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Dazzling Gleam",
+				"Petal Blizzard",
+				"Psychic"
+			],
+			"evolutions": {
+				"671": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"671": {
+			"name": "Florges",
+			"forms": {
+				"2624": {
+					"name": "Red",
+					"proto": "FLORGES_RED"
+				},
+				"2625": {
+					"name": "Yellow",
+					"proto": "FLORGES_YELLOW"
+				},
+				"2626": {
+					"name": "Orange",
+					"proto": "FLORGES_ORANGE"
+				},
+				"2627": {
+					"name": "Blue",
+					"proto": "FLORGES_BLUE"
+				},
+				"2628": {
+					"name": "White",
+					"proto": "FLORGES_WHITE"
+				}
+			},
+			"pokedex_id": 671,
+			"types": [
+				"Fairy"
+			],
+			"attack": 212,
+			"defense": 244,
+			"stamina": 186,
+			"height": 1.1,
+			"weight": 10,
+			"flee_rate": 0.05,
+			"capture_rate": 0.125,
+			"quick_moves": [
+				"Vine Whip",
+				"Tackle",
+				"Razor Leaf"
+			],
+			"charged_moves": [
+				"Moonblast",
+				"Petal Blizzard",
+				"Psychic",
+				"Disarming Voice"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"672": {
+			"name": "Skiddo",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 672,
+			"types": [
+				"Grass"
+			],
+			"attack": 123,
+			"defense": 102,
+			"stamina": 165,
+			"height": 0.9,
+			"weight": 31,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Zen Headbutt",
+				"Rock Smash"
+			],
+			"charged_moves": [
+				"Brick Break",
+				"Rock Slide",
+				"Seed Bomb"
+			],
+			"evolutions": {
+				"673": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"673": {
+			"name": "Gogoat",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 673,
+			"types": [
+				"Grass"
+			],
+			"attack": 196,
+			"defense": 146,
+			"stamina": 265,
+			"height": 1.7,
+			"weight": 91,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Zen Headbutt",
+				"Rock Smash",
+				"Vine Whip"
+			],
+			"charged_moves": [
+				"Brick Break",
+				"Rock Slide",
+				"Leaf Blade",
+				"Seed Bomb"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"674": {
+			"name": "Pancham",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 674,
+			"types": [
+				"Fighting"
+			],
+			"attack": 145,
+			"defense": 107,
+			"stamina": 167,
+			"height": 0.6,
+			"weight": 8,
+			"flee_rate": 0.09,
+			"capture_rate": 0.3,
+			"quick_moves": [
+				"Low Kick",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Low Sweep",
+				"Crunch",
+				"Body Slam"
+			],
+			"evolutions": {
+				"675": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"675": {
+			"name": "Pangoro",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 675,
+			"types": [
+				"Fighting",
+				"Dark"
+			],
+			"attack": 226,
+			"defense": 146,
+			"stamina": 216,
+			"height": 2.1,
+			"weight": 136,
+			"flee_rate": 0.07,
+			"capture_rate": 0.1,
+			"quick_moves": [
+				"Low Kick",
+				"Snarl",
+				"Bullet Punch"
+			],
+			"charged_moves": [
+				"Close Combat",
+				"Night Slash",
+				"Iron Head",
+				"Rock Slide"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"676": {
+			"name": "Furfrou",
+			"forms": {
+				"2629": {
+					"name": "Natural",
+					"proto": "FURFROU_NATURAL"
+				},
+				"2630": {
+					"name": "Heart",
+					"proto": "FURFROU_HEART"
+				},
+				"2631": {
+					"name": "Star",
+					"proto": "FURFROU_STAR"
+				},
+				"2632": {
+					"name": "Diamond",
+					"proto": "FURFROU_DIAMOND"
+				},
+				"2633": {
+					"name": "Debutante",
+					"proto": "FURFROU_DEBUTANTE"
+				},
+				"2634": {
+					"name": "Matron",
+					"proto": "FURFROU_MATRON"
+				},
+				"2635": {
+					"name": "Dandy",
+					"proto": "FURFROU_DANDY"
+				},
+				"2636": {
+					"name": "La Reine",
+					"proto": "FURFROU_LA_REINE"
+				},
+				"2637": {
+					"name": "Kabuki",
+					"proto": "FURFROU_KABUKI"
+				},
+				"2638": {
+					"name": "Pharaoh",
+					"proto": "FURFROU_PHARAOH"
+				}
+			},
+			"pokedex_id": 676,
+			"types": [
+				"Normal"
+			],
+			"attack": 164,
+			"defense": 167,
+			"stamina": 181,
+			"height": 1.2,
+			"weight": 28,
+			"flee_rate": 0.07,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Take Down",
+				"Bite",
+				"Sucker Punch"
+			],
+			"charged_moves": [
+				"Surf",
+				"Dark Pulse",
+				"Grass Knot"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"677": {
+			"name": "Espurr",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 677,
+			"types": [
+				"Psychic"
+			],
+			"attack": 120,
+			"defense": 114,
+			"stamina": 158,
+			"height": 0.3,
+			"weight": 3.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.4,
+			"quick_moves": [
+				"Confusion",
+				"Scratch"
+			],
+			"charged_moves": [
+				"Psyshock",
+				"Energy Ball",
+				"Psychic"
+			],
+			"evolutions": {
+				"678": {
+					"form": 2590,
+					"gender_requirement": 2
+				}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 1,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"678": {
+			"name": "Meowstic",
+			"forms": {
+				"2589": {
+					"name": "Normal",
+					"proto": "MEOWSTIC_NORMAL"
+				},
+				"2590": {
+					"name": "Female",
+					"proto": "MEOWSTIC_FEMALE",
+					"quick_moves": [
+						"Confusion",
+						"Charm"
+					],
+					"charged_moves": [
+						"Psychic",
+						"Energy Ball",
+						"Shadow Ball"
+					]
+				}
+			},
+			"default_form_id": 2589,
+			"pokedex_id": 678,
+			"types": [
+				"Psychic"
+			],
+			"attack": 166,
+			"defense": 167,
+			"stamina": 179,
+			"height": 0.6,
+			"weight": 8.5,
+			"flee_rate": 0.07,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Confusion",
+				"Sucker Punch"
+			],
+			"charged_moves": [
+				"Psychic",
+				"Energy Ball",
+				"Thunderbolt"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 2,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"679": {
+			"name": "Honedge",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 679,
+			"types": [
+				"Steel",
+				"Ghost"
+			],
+			"height": 0.8,
+			"weight": 2,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Tackle",
+				"Fury Cutter"
+			],
+			"charged_moves": [
+				"Night Slash",
+				"Iron Head",
+				"Gyro Ball"
+			],
+			"evolutions": {
+				"680": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"680": {
+			"name": "Doublade",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 680,
+			"types": [
+				"Steel",
+				"Ghost"
+			],
+			"height": 0.8,
+			"weight": 4.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Psycho Cut",
+				"Fury Cutter"
+			],
+			"charged_moves": [
+				"Night Slash",
+				"Iron Head",
+				"Gyro Ball"
+			],
+			"evolutions": {
+				"681": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"681": {
+			"name": "Aegislash",
+			"forms": {
+				"2639": {
+					"name": "Shield",
+					"proto": "AEGISLASH_SHIELD"
+				},
+				"2640": {
+					"name": "Blade",
+					"proto": "AEGISLASH_BLADE"
+				}
+			},
+			"pokedex_id": 681,
+			"types": [
+				"Steel",
+				"Ghost"
+			],
+			"height": 1.7,
+			"weight": 53,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Psycho Cut",
+				"Fury Cutter"
+			],
+			"charged_moves": [
+				"Night Slash",
+				"Flash Cannon",
+				"Gyro Ball",
+				"Shadow Ball"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"682": {
+			"name": "Spritzee",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 682,
+			"types": [
+				"Fairy"
+			],
+			"attack": 110,
+			"defense": 113,
+			"stamina": 186,
+			"height": 0.2,
+			"weight": 0.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Charm",
+				"Charge Beam"
+			],
+			"charged_moves": [
+				"Draining Kiss",
+				"Thunderbolt"
+			],
+			"evolutions": {
+				"683": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"683": {
+			"name": "Aromatisse",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 683,
+			"types": [
+				"Fairy"
+			],
+			"attack": 173,
+			"defense": 150,
+			"stamina": 226,
+			"height": 0.8,
+			"weight": 15.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Charm",
+				"Charge Beam"
+			],
+			"charged_moves": [
+				"Moonblast",
+				"Thunderbolt",
+				"Psychic",
+				"Draining Kiss"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"684": {
+			"name": "Swirlix",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 684,
+			"types": [
+				"Fairy"
+			],
+			"attack": 109,
+			"defense": 119,
+			"stamina": 158,
+			"height": 0.4,
+			"weight": 2.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Tackle"
+			],
+			"charged_moves": [
+				"Draining Kiss",
+				"Energy Ball"
+			],
+			"evolutions": {
+				"685": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"685": {
+			"name": "Slurpuff",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 685,
+			"types": [
+				"Fairy"
+			],
+			"attack": 168,
+			"defense": 163,
+			"stamina": 193,
+			"height": 0.8,
+			"weight": 5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Tackle",
+				"Charm"
+			],
+			"charged_moves": [
+				"Play Rough",
+				"Energy Ball",
+				"Flamethrower",
+				"Draining Kiss"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"686": {
+			"name": "Inkay",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 686,
+			"types": [
+				"Dark",
+				"Psychic"
+			],
+			"attack": 98,
+			"defense": 95,
+			"stamina": 142,
+			"height": 0.4,
+			"weight": 3.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Peck",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Psybeam",
+				"Night Slash"
+			],
+			"evolutions": {
+				"687": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"687": {
+			"name": "Malamar",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 687,
+			"types": [
+				"Dark",
+				"Psychic"
+			],
+			"attack": 177,
+			"defense": 165,
+			"stamina": 200,
+			"height": 1.5,
+			"weight": 47,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Peck",
+				"Psycho Cut"
+			],
+			"charged_moves": [
+				"Psybeam",
+				"Foul Play",
+				"Super Power",
+				"Hyper Beam"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"688": {
+			"name": "Binacle",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 688,
+			"types": [
+				"Rock",
+				"Water"
+			],
+			"attack": 96,
+			"defense": 120,
+			"stamina": 123,
+			"height": 0.5,
+			"weight": 31,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Scratch",
+				"Mud Slap"
+			],
+			"charged_moves": [
+				"Ancient Power",
+				"Cross Chop",
+				"Dig"
+			],
+			"evolutions": {
+				"689": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"689": {
+			"name": "Barbaracle",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 689,
+			"types": [
+				"Rock",
+				"Water"
+			],
+			"attack": 194,
+			"defense": 205,
+			"stamina": 176,
+			"height": 1.3,
+			"weight": 96,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Water Gun",
+				"Mud Slap",
+				"Fury Cutter"
+			],
+			"charged_moves": [
+				"Skull Bash",
+				"Cross Chop",
+				"Stone Edge",
+				"Grass Knot"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"690": {
+			"name": "Skrelp",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 690,
+			"types": [
+				"Poison",
+				"Water"
+			],
+			"attack": 109,
+			"defense": 109,
+			"stamina": 137,
+			"height": 0.5,
+			"weight": 7.3,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Water Gun",
+				"Acid"
+			],
+			"charged_moves": [
+				"Aqua Tail",
+				"Water Pulse",
+				"Twister",
+				"Sludge Bomb"
+			],
+			"evolutions": {
+				"691": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"691": {
+			"name": "Dragalge",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 691,
+			"types": [
+				"Poison",
+				"Dragon"
+			],
+			"attack": 177,
+			"defense": 207,
+			"stamina": 163,
+			"height": 1.8,
+			"weight": 81.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Water Gun",
+				"Acid",
+				"Dragon Tail"
+			],
+			"charged_moves": [
+				"Hydro Pump",
+				"Aqua Tail",
+				"Outrage",
+				"Gunk Shot"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"692": {
+			"name": "Clauncher",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 692,
+			"types": [
+				"Water"
+			],
+			"attack": 108,
+			"defense": 117,
+			"stamina": 137,
+			"height": 0.5,
+			"weight": 8.3,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Water Gun",
+				"Smack Down"
+			],
+			"charged_moves": [
+				"Water Pulse",
+				"Crabhammer",
+				"Aqua Jet"
+			],
+			"evolutions": {
+				"693": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"693": {
+			"name": "Clawitzer",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 693,
+			"types": [
+				"Water"
+			],
+			"attack": 221,
+			"defense": 171,
+			"stamina": 174,
+			"height": 1.3,
+			"weight": 35.3,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Water Gun",
+				"Smack Down"
+			],
+			"charged_moves": [
+				"Water Pulse",
+				"Dark Pulse",
+				"Ice Beam",
+				"Crabhammer"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"694": {
+			"name": "Helioptile",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 694,
+			"types": [
+				"Electric",
+				"Normal"
+			],
+			"attack": 115,
+			"defense": 78,
+			"stamina": 127,
+			"height": 0.5,
+			"weight": 6,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Quick Attack",
+				"Thunder Shock"
+			],
+			"charged_moves": [
+				"Parabolic Charge",
+				"Bulldoze",
+				"Discharge"
+			],
+			"evolutions": {
+				"695": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"695": {
+			"name": "Heliolisk",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 695,
+			"types": [
+				"Electric",
+				"Normal"
+			],
+			"attack": 219,
+			"defense": 168,
+			"stamina": 158,
+			"height": 1,
+			"weight": 21,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Quick Attack",
+				"Volt Switch",
+				"Mud Slap"
+			],
+			"charged_moves": [
+				"Parabolic Charge",
+				"Bulldoze",
+				"Thunderbolt",
+				"Grass Knot"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"696": {
+			"name": "Tyrunt",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 696,
+			"types": [
+				"Rock",
+				"Dragon"
+			],
+			"attack": 158,
+			"defense": 123,
+			"stamina": 151,
+			"height": 0.8,
+			"weight": 26,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Dragon Tail",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Stomp",
+				"Ancient Power",
+				"Dragon Claw"
+			],
+			"evolutions": {
+				"697": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"697": {
+			"name": "Tyrantrum",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 697,
+			"types": [
+				"Rock",
+				"Dragon"
+			],
+			"attack": 227,
+			"defense": 191,
+			"stamina": 193,
+			"height": 2.5,
+			"weight": 270,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Dragon Tail",
+				"Charm",
+				"Rock Throw"
+			],
+			"charged_moves": [
+				"Crunch",
+				"Stone Edge",
+				"Outrage",
+				"Earthquake"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"698": {
+			"name": "Amaura",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 698,
+			"types": [
+				"Rock",
+				"Ice"
+			],
+			"attack": 124,
+			"defense": 109,
+			"stamina": 184,
+			"height": 1.3,
+			"weight": 25.2,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Powder Snow",
+				"Frost Breath",
+				"Mirror Coat"
+			],
+			"charged_moves": [
+				"Weather Ball",
+				"Ancient Power",
+				"Aurora Beam",
+				"Thunderbolt"
+			],
+			"evolutions": {
+				"699": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"699": {
+			"name": "Aurorus",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 699,
+			"types": [
+				"Rock",
+				"Ice"
+			],
+			"attack": 186,
+			"defense": 163,
+			"stamina": 265,
+			"height": 2.7,
+			"weight": 225,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Powder Snow",
+				"Frost Breath",
+				"Mirror Coat",
+				"Rock Throw"
+			],
+			"charged_moves": [
+				"Weather Ball",
+				"Ancient Power",
+				"Blizzard",
+				"Thunderbolt",
+				"Hyper Beam"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"700": {
+			"name": "Sylveon",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 700,
+			"types": [
+				"Fairy"
+			],
+			"attack": 203,
+			"defense": 205,
+			"stamina": 216,
+			"height": 1,
+			"weight": 23.5,
+			"flee_rate": 0.06,
+			"capture_rate": 0.125,
+			"quick_moves": [
+				"Charm",
+				"Quick Attack"
+			],
+			"charged_moves": [
+				"Moonblast",
+				"Dazzling Gleam",
+				"Draining Kiss"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"701": {
+			"name": "Hawlucha",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 701,
+			"types": [
+				"Fighting",
+				"Flying"
+			],
+			"attack": 195,
+			"defense": 153,
+			"stamina": 186,
+			"height": 0.8,
+			"weight": 21.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Wing Attack",
+				"Low Kick",
+				"Poison Jab"
+			],
+			"charged_moves": [
+				"Flying Press",
+				"Sky Attack",
+				"X Scissor",
+				"Power Up"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"702": {
+			"name": "Dedenne",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 702,
+			"types": [
+				"Electric",
+				"Fairy"
+			],
+			"attack": 164,
+			"defense": 134,
+			"stamina": 167,
+			"height": 0.2,
+			"weight": 2.2,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Tackle",
+				"Thunder Shock"
+			],
+			"charged_moves": [
+				"Parabolic Charge",
+				"Discharge",
+				"Play Rough"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"703": {
+			"name": "Carbink",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 703,
+			"types": [
+				"Rock",
+				"Fairy"
+			],
+			"attack": 95,
+			"defense": 285,
+			"stamina": 137,
+			"height": 0.3,
+			"weight": 5.7,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Tackle",
+				"Rock Throw"
+			],
+			"charged_moves": [
+				"Rock Slide",
+				"Moonblast",
+				"Power Gem"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"704": {
+			"name": "Goomy",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 704,
+			"types": [
+				"Dragon"
+			],
+			"attack": 101,
+			"defense": 112,
+			"stamina": 128,
+			"height": 0.3,
+			"weight": 2.8,
+			"flee_rate": 0.09,
+			"capture_rate": 0.4,
+			"quick_moves": [
+				"Water Gun",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Dragon Pulse",
+				"Sludge Wave",
+				"Muddy Water"
+			],
+			"evolutions": {
+				"705": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"705": {
+			"name": "Sliggoo",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 705,
+			"types": [
+				"Dragon"
+			],
+			"attack": 159,
+			"defense": 176,
+			"stamina": 169,
+			"height": 0.8,
+			"weight": 17.5,
+			"flee_rate": 0.07,
+			"capture_rate": 0.1,
+			"quick_moves": [
+				"Water Gun",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Dragon Pulse",
+				"Sludge Wave",
+				"Muddy Water",
+				"Water Pulse"
+			],
+			"evolutions": {
+				"706": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"706": {
+			"name": "Goodra",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 706,
+			"types": [
+				"Dragon"
+			],
+			"attack": 220,
+			"defense": 242,
+			"stamina": 207,
+			"height": 2,
+			"weight": 150.5,
+			"flee_rate": 0.05,
+			"capture_rate": 0.05,
+			"quick_moves": [
+				"Water Gun",
+				"Dragon Breath"
+			],
+			"charged_moves": [
+				"Draco Meteor",
+				"Sludge Wave",
+				"Muddy Water",
+				"Power Whip"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"707": {
+			"name": "Klefki",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 707,
+			"types": [
+				"Steel",
+				"Fairy"
+			],
+			"attack": 160,
+			"defense": 179,
+			"stamina": 149,
+			"height": 0.2,
+			"weight": 3,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Astonish",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Flash Cannon",
+				"Play Rough",
+				"Draining Kiss",
+				"Foul Play"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 4,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"708": {
+			"name": "Phantump",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 708,
+			"types": [
+				"Ghost",
+				"Grass"
+			],
+			"attack": 125,
+			"defense": 103,
+			"stamina": 125,
+			"height": 0.4,
+			"weight": 7,
+			"flee_rate": 0.1,
+			"capture_rate": 0.3,
+			"quick_moves": [
+				"Astonish",
+				"Tackle"
+			],
+			"charged_moves": [
+				"Seed Bomb",
+				"Shadow Ball",
+				"Foul Play"
+			],
+			"evolutions": {
+				"709": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"709": {
+			"name": "Trevenant",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 709,
+			"types": [
+				"Ghost",
+				"Grass"
+			],
+			"attack": 201,
+			"defense": 154,
+			"stamina": 198,
+			"height": 1.5,
+			"weight": 71,
+			"flee_rate": 0.05,
+			"capture_rate": 0.15,
+			"quick_moves": [
+				"Shadow Claw",
+				"Sucker Punch"
+			],
+			"charged_moves": [
+				"Seed Bomb",
+				"Shadow Ball",
+				"Foul Play"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"710": {
+			"name": "Pumpkaboo",
+			"forms": {
+				"2641": {
+					"name": "Small",
+					"proto": "PUMPKABOO_SMALL"
+				},
+				"2642": {
+					"name": "Average",
+					"proto": "PUMPKABOO_AVERAGE"
+				},
+				"2643": {
+					"name": "Large",
+					"proto": "PUMPKABOO_LARGE"
+				},
+				"2644": {
+					"name": "Super",
+					"proto": "PUMPKABOO_SUPER"
+				}
+			},
+			"pokedex_id": 710,
+			"types": [
+				"Ghost",
+				"Grass"
+			],
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Astonish",
+				"Razor Leaf"
+			],
+			"charged_moves": [
+				"Grass Knot",
+				"Shadow Sneak",
+				"Foul Play",
+				"Earthquake"
+			],
+			"evolutions": {
+				"711": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75
+		},
+		"711": {
+			"name": "Gourgeist",
+			"forms": {
+				"2645": {
+					"name": "Small",
+					"proto": "GOURGEIST_SMALL"
+				},
+				"2646": {
+					"name": "Average",
+					"proto": "GOURGEIST_AVERAGE"
+				},
+				"2647": {
+					"name": "Large",
+					"proto": "GOURGEIST_LARGE"
+				},
+				"2648": {
+					"name": "Super",
+					"proto": "GOURGEIST_SUPER"
+				}
+			},
+			"pokedex_id": 711,
+			"types": [
+				"Ghost",
+				"Grass"
+			],
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Hex",
+				"Razor Leaf"
+			],
+			"charged_moves": [
+				"Seed Bomb",
+				"Shadow Ball",
+				"Foul Play",
+				"Fire Blast"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75
+		},
+		"712": {
+			"name": "Bergmite",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 712,
+			"types": [
+				"Ice"
+			],
+			"attack": 117,
+			"defense": 120,
+			"stamina": 146,
+			"height": 1,
+			"weight": 99.5,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Bite",
+				"Mirror Coat"
+			],
+			"charged_moves": [
+				"Crunch",
+				"Icy Wind"
+			],
+			"evolutions": {
+				"713": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"713": {
+			"name": "Avalugg",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 713,
+			"types": [
+				"Ice"
+			],
+			"attack": 196,
+			"defense": 240,
+			"stamina": 216,
+			"height": 2,
+			"weight": 505,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Bite",
+				"Ice Fang",
+				"Mirror Coat"
+			],
+			"charged_moves": [
+				"Crunch",
+				"Avalanche",
+				"Earthquake",
+				"Body Slam"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_distance": 3,
+			"third_move_stardust": 50000,
+			"third_move_candy": 50,
+			"gym_defender_eligible": true
+		},
+		"714": {
+			"name": "Noibat",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 714,
+			"types": [
+				"Flying",
+				"Dragon"
+			],
+			"attack": 83,
+			"defense": 73,
+			"stamina": 120,
+			"height": 0.5,
+			"weight": 8,
+			"flee_rate": 0.1,
+			"capture_rate": 0.3,
+			"quick_moves": [
+				"Wing Attack",
+				"Bite"
+			],
+			"charged_moves": [
+				"Dragon Pulse",
+				"Air Cutter",
+				"Heat Wave"
+			],
+			"evolutions": {
+				"715": {}
+			},
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 4,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"715": {
+			"name": "Noivern",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 715,
+			"types": [
+				"Flying",
+				"Dragon"
+			],
+			"attack": 205,
+			"defense": 175,
+			"stamina": 198,
+			"height": 1.5,
+			"weight": 85,
+			"flee_rate": 0.05,
+			"capture_rate": 0.15,
+			"quick_moves": [
+				"Air Slash",
+				"Bite"
+			],
+			"charged_moves": [
+				"Draco Meteor",
+				"Hurricane",
+				"Heat Wave",
+				"Psychic"
+			],
+			"legendary": false,
+			"mythic": false,
+			"buddy_group_number": 6,
+			"buddy_distance": 5,
+			"third_move_stardust": 75000,
+			"third_move_candy": 75,
+			"gym_defender_eligible": true
+		},
+		"716": {
+			"name": "Xerneas",
+			"forms": {
+				"2649": {
+					"name": "Neutral",
+					"proto": "XERNEAS_NEUTRAL"
+				},
+				"2650": {
+					"name": "Active",
+					"proto": "XERNEAS_ACTIVE"
+				}
+			},
+			"pokedex_id": 716,
+			"types": [
+				"Fairy"
+			],
+			"attack": 275,
+			"defense": 203,
+			"stamina": 270,
+			"height": 3,
+			"weight": 215,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Tackle",
+				"Zen Headbutt"
+			],
+			"charged_moves": [
+				"Moonblast",
+				"Megahorn",
+				"Close Combat",
+				"Giga Impact",
+				"Thunder"
+			],
+			"legendary": true,
+			"mythic": false,
+			"buddy_distance": 20,
+			"third_move_stardust": 100000,
+			"third_move_candy": 100
+		},
+		"717": {
+			"name": "Yveltal",
+			"forms": {
+				"0": {}
+			},
+			"pokedex_id": 717,
+			"types": [
+				"Dark",
+				"Flying"
+			],
+			"attack": 275,
+			"defense": 203,
+			"stamina": 270,
+			"height": 5.8,
+			"weight": 203,
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Sucker Punch",
+				"Snarl",
+				"Gust"
+			],
+			"charged_moves": [
+				"Dark Pulse",
+				"Hurricane",
+				"Focus Blast",
+				"Hyper Beam",
+				"Psychic"
+			],
+			"legendary": true,
+			"mythic": false,
+			"buddy_distance": 20,
+			"third_move_stardust": 100000,
+			"third_move_candy": 100
+		},
+		"718": {
+			"name": "Zygarde",
+			"forms": {
+				"2591": {
+					"name": "Ten Percent",
+					"proto": "ZYGARDE_TEN_PERCENT"
+				},
+				"2592": {
+					"name": "Fifty Percent",
+					"proto": "ZYGARDE_FIFTY_PERCENT"
+				},
+				"2593": {
+					"name": "Complete",
+					"proto": "ZYGARDE_COMPLETE"
+				}
+			},
+			"pokedex_id": 718,
+			"types": [
+				"Dragon",
+				"Ground"
+			],
+			"flee_rate": 0.1,
+			"capture_rate": 0.2,
+			"quick_moves": [
+				"Dragon Tail",
+				"Bite",
+				"Zen Headbutt"
+			],
+			"charged_moves": [
+				"Outrage",
+				"Earthquake",
+				"Crunch",
+				"Hyper Beam",
+				"Bulldoze"
+			],
+			"legendary": true,
+			"mythic": false,
+			"buddy_distance": 20,
+			"third_move_stardust": 100000,
+			"third_move_candy": 100
+		},
+		"719": {
+			"name": "Diancie",
+			"forms": {
+				"0": {}
+			},
+			"temp_evolutions": {
+				"1": {
+					"attack": 342,
+					"defense": 235,
+					"stamina": 137,
+					"unreleased": true,
+					"types": [
+						"Fairy",
+						"Rock"
+					]
+				}
+			}
+		},
+		"720": {
+			"name": "Hoopa",
+			"forms": {
+				"2651": {
+					"name": "Confined",
+					"proto": "HOOPA_CONFINED"
+				},
+				"2652": {
+					"name": "Unbound",
+					"proto": "HOOPA_UNBOUND"
+				}
+			}
+		},
+		"721": {
+			"name": "Volcanion",
+			"forms": {
+				"0": {}
+			}
+		},
 		"808": {
 			"name": "Meltan",
 			"forms": {
@@ -34136,6 +37432,23 @@
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
 			"gym_defender_eligible": true
+		},
+		"866": {
+			"name": "Mr Rime",
+			"forms": {
+				"2513": {
+					"name": "Normal",
+					"proto": "MR_RIME_NORMAL"
+				},
+				"2514": {
+					"name": "Shadow",
+					"proto": "MR_RIME_SHADOW"
+				},
+				"2515": {
+					"name": "Purified",
+					"proto": "MR_RIME_PURIFIED"
+				}
+			}
 		},
 		"867": {
 			"name": "Runerigus",
@@ -36015,7 +39328,7 @@
 			"name": "Aeroblast",
 			"proto": "V0335_MOVE_AEROBLAST",
 			"type": "Flying",
-			"power": 180
+			"power": 170
 		},
 		"336": {
 			"name": "Techno Blast Normal"
@@ -36060,7 +39373,10 @@
 			"power": 16
 		},
 		"346": {
-			"name": "Incinerate"
+			"name": "Incinerate",
+			"proto": "V0346_MOVE_INCINERATE_FAST",
+			"type": "Fire",
+			"power": 15
 		},
 		"347": {
 			"name": "Dark Void"

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -2497,7 +2497,11 @@ const getIconSize = (type, id, form, weight) => {
         case 'quest':       filterId = id; break;
         case 'invasion':    filterId = id; break;
         case 'spawnpoint':  filterId = id; break;
-        case 'pokemon':     filterId = form === 0 ? `${id}-${masterfile.pokemon[id].default_form_id}` : `${id}-${form}`; break;
+        case 'pokemon': {
+            const realForm = form === 0 ? masterfile.pokemon[id].default_form_id || 0 : form;
+            filterId = realForm === 0 ? `${id}` : `${id}-${realForm}`;
+            break;
+        }
         case 'nest':        filterId = `p${id}`; break;
         case 'device':      filterId = id; break;
     }
@@ -2734,7 +2738,7 @@ function getPokemonPopupContent (pokemon) {
     const pkmn = masterfile.pokemon[pokemon.pokemon_id];
     if (pkmn !== undefined && pkmn !== null) {
         const types = pkmn.types;
-        if (types !== null && types.length > 0) {
+        if (types && types.length > 0) {
             content += '<div class="col">';
             if (types.length === 2) {
                 content += `<img src="/img/type/${types[0].toLowerCase()}.png" height="16" width="16">&nbsp;`;
@@ -3159,7 +3163,7 @@ function getGymPopupContent (gym) {
             const pkmn = masterfile.pokemon[gym.raid_pokemon_id];
             if (pkmn !== undefined && pkmn !== null) {
                 const types = pkmn.types;
-                if (types !== null && types.length > 0) {
+                if (types && types.length > 0) {
                     content += '<div class="col text-nowrap">';
                     if (types.length === 2) {
                         content += `<img src="/img/type/${types[0].toLowerCase()}.png" height="16" width="16">&nbsp;`;
@@ -5560,7 +5564,7 @@ let masterfileFilter = (pokemonId, filter) => {
     const pkmn = masterfile.pokemon[pokemonId];
     let matches = false;
     switch(filter[0]) {
-        case 'regionalForm': matches = pkmn.forms[filter[2]].proto.includes(filter[1]); break;
+        case 'regionalForm': matches = (pkmn.forms[filter[2]] || { proto: '' }).proto.includes(filter[1]); break;
         case 'legendary':    matches = pkmn.legendary; break;
         case 'mythical':     matches = pkmn.mythic; break;
     }


### PR DESCRIPTION
It looks like Niantic is still going to use `FORM_UNSET` for the new Pokemon. Therefore unfortunately we have to add it back.