### PR TITLE
docs: Update docker compose + documentation

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,7 +13,7 @@ services:
       - sh
       - -c
       - |
-        npm install
+        npm run update
         npm start
     volumes:
       - .:/app

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -2,9 +2,13 @@ version: '3.2'
 
 services:
   mapjs:
-    build: .
+    build: node:12
     restart: unless-stopped
     working_dir: /app
+    environment:
+      HEALTHCHECK_SECRET: "some_super_secret_value"
+    healthcheck:
+      test: "curl -fH \"Healthcheck-Secret: $HEALTHCHECK_SECRET\" http://localhost:8080 || exit 1"
     command:
       - sh
       - -c

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   mapjs:
-    build: node:12
+    image: node:12
     restart: unless-stopped
     working_dir: /app
     environment:

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -18,7 +18,7 @@
     cp docker-compose.example.yml docker-compose.yml
     ```
 
-1. Fill out your docker-compose.yml file
+1. Fill out your docker-compose.yml file. Change your `HEALTHCHECK_SECRET` variable.
 
     ```sh
     vi docker-compose.yml


### PR DESCRIPTION
Docker build was failing. We're going to use the node:12 image for now
which allows docker-compose to actually work. Also added in the health
check from #282