### PR TITLE
Dynamic-ish Cell Border Colors

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -366,6 +366,9 @@ $(function () {
         selectedTileserver = this.value;
         store('tileserver', this.value);
         map.removeLayer(tileLayer);
+        $.each(cellMarkers, function (index, cell) {
+            map.removeLayer(cell.marker);
+        });
 
         let scale = '';
         if (L.Browser.retina) {
@@ -3767,6 +3770,14 @@ function getCellMarker (cell, ts) {
     return polygon;
 }
 
+function getCellStyleColors (selectedTileserver) {
+    let colorObject = 'black'
+    if (selectedTileserver === 'Dark Matter' || selectedTileserver === 'Satellite') {
+        colorObject = 'red'
+    }
+    return colorObject
+}
+
 function getCellStyle (cell, ts) {
     const ago = ts - cell.updated;
     let value;
@@ -3787,9 +3798,9 @@ function getSubmissionPlacementCellMarker (cell, ts) {
 
 function getSubmissionPlacementCellStyle (cell, ts) {
     if (cell.blocked) {
-        return { fillColor: 'black', color: 'black', opacity: 0.75, fillOpacity: 0.25, weight: 0.1 };
+        return { fillColor: 'black', color: getCellStyleColors(selectedTileserver), opacity: 0.75, fillOpacity: 0.25, weight: 0.35 };
     } else {
-        return { fillColor: 'green', color: 'black', opacity: 0.75, fillOpacity: 0.0, weight: 0.1 };
+        return { fillColor: 'green', color: getCellStyleColors(selectedTileserver), opacity: 0.75, fillOpacity: 0.0, weight: 0.35 };
     }
 }
 
@@ -3829,9 +3840,9 @@ function getSubmissionTypeCellStyle (cell, ts) {
     } else if ((cell.count === 4 && cell.count_gyms < 2) || (cell.count === 18 && cell.count_gyms < 3)) {
         return { fillColor: 'orange', color: 'red', opacity: 0.75, fillOpacity: 0.5, weight: 0.75 };
     } else if (cell.count >= 20) {
-        return { fillColor: 'black', color: 'black', opacity: 0.75, fillOpacity: 0.25, weight: 0.75 };
+        return { fillColor: 'black', color: getCellStyleColors(selectedTileserver), opacity: 0.75, fillOpacity: 0.25, weight: 0.8 };
     } else {
-        return { fillColor: 'blue', color: 'black', opacity: 0.75, fillOpacity: 0.0, weight: 0.75 };
+        return { fillColor: 'blue', color: getCellStyleColors(selectedTileserver), opacity: 0.75, fillOpacity: 0.0, weight: 0.8 };
     }
 }
 


### PR DESCRIPTION
- Black for "lighter" tileservers
- Red for "darker" tileservers

Automatically adjusts based off of selected tileserver. Does refresh without having to refresh the page but usually takes a second after selecting the tileserver.