### PR TITLE
Area restrictions

### DIFF
--- a/src/configs/config.example.json
+++ b/src/configs/config.example.json
@@ -18,10 +18,7 @@
         "startLon": 0,
         "startZoom": 12,
         "minZoom": 10,
-        "maxZoom": 18,
-        "areaPolygons": {
-            "area1": ["latitude longitude", "..."]
-        }
+        "maxZoom": 18
     },
     "areas": {
         "test": { "lat": 4.01, "lon": 117.01, "zoom": 15 }

--- a/src/configs/config.example.json
+++ b/src/configs/config.example.json
@@ -18,7 +18,10 @@
         "startLon": 0,
         "startZoom": 12,
         "minZoom": 10,
-        "maxZoom": 18
+        "maxZoom": 18,
+        "area_polygons": {
+            "area1": ["latitude longitude", "..."]
+        }
     },
     "areas": {
         "test": { "lat": 4.01, "lon": 117.01, "zoom": 15 }
@@ -61,6 +64,10 @@
         "allowedGuilds": [],
         "blockedGuilds": [],
         "allowedUsers": [],
+        "area_restrictions": {
+            "fullRoleId": [],
+            "restrictedRoleId": ["area1"]
+        },
         "perms": {
             "map": {
                 "enabled": true,

--- a/src/configs/config.example.json
+++ b/src/configs/config.example.json
@@ -19,7 +19,7 @@
         "startZoom": 12,
         "minZoom": 10,
         "maxZoom": 18,
-        "area_polygons": {
+        "areaPolygons": {
             "area1": ["latitude longitude", "..."]
         }
     },
@@ -64,7 +64,7 @@
         "allowedGuilds": [],
         "blockedGuilds": [],
         "allowedUsers": [],
-        "area_restrictions": {
+        "areaRestrictions": {
             "fullRoleId": [],
             "restrictedRoleId": ["area1"]
         },

--- a/src/configs/config.example.json
+++ b/src/configs/config.example.json
@@ -61,10 +61,7 @@
         "allowedGuilds": [],
         "blockedGuilds": [],
         "allowedUsers": [],
-        "areaRestrictions": {
-            "fullRoleId": [],
-            "restrictedRoleId": ["area1"]
-        },
+        "areaRestrictions": {},
         "perms": {
             "map": {
                 "enabled": true,

--- a/src/configs/config.example.json
+++ b/src/configs/config.example.json
@@ -62,9 +62,14 @@
         "blockedGuilds": [],
         "allowedUsers": [],
         "areaRestrictions": {
-            "unrestrictedRoleId": [],
-            "restrictedRoleId1": ["area1"],
-            "restrictedRoleId2": ["area1", "area2"]
+            "role1": {
+                "roles": [],
+                "areas": []
+            },
+            "role2": {
+                "roles": [],
+                "areas": []
+            }
         },
         "perms": {
             "map": {

--- a/src/configs/config.example.json
+++ b/src/configs/config.example.json
@@ -61,7 +61,11 @@
         "allowedGuilds": [],
         "blockedGuilds": [],
         "allowedUsers": [],
-        "areaRestrictions": {},
+        "areaRestrictions": {
+            "unrestrictedRoleId": [],
+            "restrictedRoleId1": ["area1"],
+            "restrictedRoleId2": ["area1", "area2"]
+        },
         "perms": {
             "map": {
                 "enabled": true,

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -93,7 +93,7 @@
           "device": { "small": 15, "normal": 30, "large": 50, "huge": 70 }
       },
       "portalMods": { "oldColor": "blue", "newColor": "green" },
-      "area_polygons": {}
+      "areaPolygons": {}
   },
   "header": {
       "left": [],
@@ -133,7 +133,7 @@
       "allowedGuilds": [],
       "blockedGuilds": [],
       "allowedUsers": [],
-      "area_restrictions": {},
+      "areaRestrictions": {},
       "perms": {
           "map": {
               "enabled": true,

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -92,8 +92,7 @@
           "nest": { "small": 20, "normal": 40, "large": 60, "huge": 80 },
           "device": { "small": 15, "normal": 30, "large": 50, "huge": 70 }
       },
-      "portalMods": { "oldColor": "blue", "newColor": "green" },
-      "areaPolygons": {}
+      "portalMods": { "oldColor": "blue", "newColor": "green" }
   },
   "header": {
       "left": [],

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -92,7 +92,8 @@
           "nest": { "small": 20, "normal": 40, "large": 60, "huge": 80 },
           "device": { "small": 15, "normal": 30, "large": 50, "huge": 70 }
       },
-      "portalMods": { "oldColor": "blue", "newColor": "green" }
+      "portalMods": { "oldColor": "blue", "newColor": "green" },
+      "area_polygons": {}
   },
   "header": {
       "left": [],
@@ -132,6 +133,7 @@
       "allowedGuilds": [],
       "blockedGuilds": [],
       "allowedUsers": [],
+      "area_restrictions": {},
       "perms": {
           "map": {
               "enabled": true,

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1552,7 +1552,7 @@ const getAreaRestrictionSql = (areaRestrictions) => {
         areaRestrictionsSQL += ')';
     }
     return areaRestrictionsSQL;
-}
+};
 
 class Ring {
     constructor(lat, lon, radius) {

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -27,13 +27,14 @@ const dbSelection = (category) => {
     return dbSelection;
 };
 
-const getPokemon = async (minLat, maxLat, minLon, maxLon, showPVP, showIV, updated, pokemonFilterExclude = null, pokemonFilterIV = null) => {
+const getPokemon = async (minLat, maxLat, minLon, maxLon, showPVP, showIV, updated, pokemonFilterExclude = null, pokemonFilterIV = null, areaRestrictions = []) => {
     const pokemonLookup = {};
     const formLookup = {};
 
     let includeBigKarp = false;
     let includeTinyRat = false;
     let onlyVerifiedTimersSQL = '';
+    let areaRestrictionsSQL = getAreaRestrictionSql(areaRestrictions);
     let interestedLevelCaps = [];
     let interestedMegas = [];
     for (const key of pokemonFilterExclude || []) {
@@ -122,7 +123,8 @@ const getPokemon = async (minLat, maxLat, minLon, maxLon, showPVP, showIV, updat
             first_seen_timestamp, changed, cell_id, expire_timestamp_verified, shiny, username,
             capture_1, capture_2, capture_3, pvp_rankings_great_league, pvp_rankings_ultra_league
     FROM pokemon
-    WHERE expire_timestamp >= UNIX_TIMESTAMP() AND lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? AND updated > ? ${onlyVerifiedTimersSQL}`;
+    WHERE expire_timestamp >= UNIX_TIMESTAMP() AND lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? AND updated > ?
+    ${onlyVerifiedTimersSQL} ${areaRestrictionsSQL}`;
     const args = [minLat, maxLat, minLon, maxLon, updated];
     const results = await dbSelection('pokemon').query(sql, args).catch(err => {
         console.error('Failed to execute query:', sql, 'with arguments:', args, '\r\nError:', err);
@@ -231,7 +233,7 @@ const getPokemon = async (minLat, maxLat, minLon, maxLon, showPVP, showIV, updat
     return pokemon;
 };
 
-const getGyms = async (minLat, maxLat, minLon, maxLon, updated = 0, showRaids = false, showGyms = true, permGymDetails = true, raidFilterExclude = null, gymFilterExclude = null) => {
+const getGyms = async (minLat, maxLat, minLon, maxLon, updated = 0, showRaids = false, showGyms = true, permGymDetails = true, raidFilterExclude = null, gymFilterExclude = null, areaRestrictions = []) => {
     let excludedLevels = []; //int
     let excludeAllButEx = false;
     let excludeAllButBattles = false;
@@ -301,6 +303,7 @@ const getGyms = async (minLat, maxLat, minLon, maxLon, updated = 0, showRaids = 
     let excludeAllButBattlesSQL = '';
     let excludeTeamSQL = '';
     let excludeAvailableSlotsSQL = '';
+    let areaRestrictionsSQL = getAreaRestrictionSql(areaRestrictions);
     let args = [minLat, maxLat, minLon, maxLon, updated];
 
     if (showRaids) {
@@ -391,7 +394,7 @@ const getGyms = async (minLat, maxLat, minLon, maxLon, updated = 0, showRaids = 
             raid_end_timestamp IS NULL OR raid_end_timestamp < UNIX_TIMESTAMP() OR raid_pokemon_id IS NULL OR
             (raid_pokemon_form = 0 ${sqlExcludePokemon}) OR raid_pokemon_form NOT IN (0 ${sqlExcludeForms})
         ) ${excludeTeamSQL} ${excludeAvailableSlotsSQL}
-        ${excludeAllButExSQL} ${excludeAllButBattlesSQL}
+        ${excludeAllButExSQL} ${excludeAllButBattlesSQL} ${areaRestrictionsSQL}
     `;
     if (!showGyms) {
         sql += ' AND raid_end_timestamp IS NOT NULL AND raid_end_timestamp >= UNIX_TIMESTAMP()';
@@ -467,7 +470,7 @@ const getGyms = async (minLat, maxLat, minLon, maxLon, updated = 0, showRaids = 
     return gyms;
 };
 
-const getPokestops = async (minLat, maxLat, minLon, maxLon, updated = 0, showPokestops = true, showQuests = false, showLures = false, showInvasions = false, questFilterExclude = null, pokestopFilterExclude = null, invasionFilterExclude = null) => {
+const getPokestops = async (minLat, maxLat, minLon, maxLon, updated = 0, showPokestops = true, showQuests = false, showLures = false, showInvasions = false, questFilterExclude = null, pokestopFilterExclude = null, invasionFilterExclude = null, areaRestrictions = []) => {
     let excludedTypes = []; //int
     let excludedPokemon = []; //int
     const excludedForms = [];
@@ -536,6 +539,7 @@ const getPokestops = async (minLat, maxLat, minLon, maxLon, updated = 0, showPok
     let excludeItemSQL = '';
     let excludeInvasionSQL = '';
     let excludePokestopSQL = '';
+    let areaRestrictionsSQL = getAreaRestrictionSql(areaRestrictions);
 
     if (showQuests) {
         if (excludedTypes.length === 0) {
@@ -677,7 +681,7 @@ const getPokestops = async (minLat, maxLat, minLon, maxLon, updated = 0, showPok
             incident_expire_timestamp, grunt_type, sponsor_id${arScanEligible}
     FROM pokestop
     WHERE lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? AND updated > ? AND deleted = false AND
-        (false ${excludeTypeSQL} ${excludePokemonSQL} ${excludeEvolutionSQL} ${excludeItemSQL} ${excludePokestopSQL} ${excludeInvasionSQL})
+        (false ${excludeTypeSQL} ${excludePokemonSQL} ${excludeEvolutionSQL} ${excludeItemSQL} ${excludePokestopSQL} ${excludeInvasionSQL}) ${areaRestrictionsSQL}
     `;
     const results = await dbSelection('pokestop').query(sql, args);
     let pokestops = [];
@@ -766,7 +770,7 @@ const getPokestops = async (minLat, maxLat, minLon, maxLon, updated = 0, showPok
     return pokestops;
 };
 
-const getSpawnpoints = async (minLat, maxLat, minLon, maxLon, updated, spawnpointFilterExclude = null) => {
+const getSpawnpoints = async (minLat, maxLat, minLon, maxLon, updated, spawnpointFilterExclude = null, areaRestrictions = []) => {
     let excludeWithoutTimer = false;
     let excludeWithTimer = false;
     if (spawnpointFilterExclude) {
@@ -790,11 +794,12 @@ const getSpawnpoints = async (minLat, maxLat, minLon, maxLon, updated, spawnpoin
     } else {
         excludeTimerSQL = 'AND (despawn_sec IS NULL AND despawn_sec IS NOT NULL)';
     }
+    let areaRestrictionsSQL = getAreaRestrictionSql(areaRestrictions);
 
     const sql = `
     SELECT id, lat, lon, updated, despawn_sec
     FROM spawnpoint
-    WHERE lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? AND updated > ? ${excludeTimerSQL}
+    WHERE lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? AND updated > ? ${excludeTimerSQL} ${areaRestrictionsSQL}
     `;
 
     let args = [minLat, maxLat, minLon, maxLon, updated];
@@ -1077,7 +1082,7 @@ const getWeather = async (minLat, maxLat, minLon, maxLon, updated, weatherFilter
     return weather;
 };
 
-const getNests = async (minLat, maxLat, minLon, maxLon, nestFilterExclude = null) => {
+const getNests = async (minLat, maxLat, minLon, maxLon, nestFilterExclude = null, areaRestrictions = []) => {
     const minLatReal = minLat - 0.01;
     const maxLatReal = maxLat + 0.01;
     const minLonReal = minLon - 0.01;
@@ -1120,11 +1125,12 @@ const getNests = async (minLat, maxLat, minLon, maxLon, nestFilterExclude = null
         excludeAverageSQL = ' AND pokemon_avg >= ?';
         args.push(averageCountFilter);
     }
+    let areaRestrictionsSQL = getAreaRestrictionSql(areaRestrictions);
 
     const sql = `
     SELECT nest_id, lat, lon, name, pokemon_id, pokemon_count, pokemon_avg, updated
     FROM nests
-    WHERE lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? ${excludeAverageSQL} ${excludePokemonSQL}
+    WHERE lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? ${excludeAverageSQL} ${excludePokemonSQL} ${areaRestrictionsSQL}
     `;
     for (let i = 0; i < excludedPokemon.length; i++) {
         args.push(excludedPokemon[i]);
@@ -1137,7 +1143,7 @@ const getNests = async (minLat, maxLat, minLon, maxLon, nestFilterExclude = null
     return null;
 };
 
-const getPortals = async (minLat, maxLat, minLon, maxLon, portalFilterExclude = null) => {
+const getPortals = async (minLat, maxLat, minLon, maxLon, portalFilterExclude = null, areaRestrictions = []) => {
     const minLatReal = minLat - 0.01;
     const maxLatReal = maxLat + 0.01;
     const minLonReal = minLon - 0.01;
@@ -1158,11 +1164,12 @@ const getPortals = async (minLat, maxLat, minLon, maxLon, portalFilterExclude = 
     } else if (!showNewPortals && !showOldPortals) {
         sqlExcludeCreate = 'AND FALSE';
     }
+    let areaRestrictionsSQL = getAreaRestrictionSql(areaRestrictions);
 
     const sql = `
     SELECT id, external_id, lat, lon, name, url, updated, imported, checked
     FROM ingress_portals
-    WHERE lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? ${sqlExcludeCreate}
+    WHERE lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? ${sqlExcludeCreate} ${areaRestrictionsSQL}
     `;
     const args = [minLatReal, maxLatReal, minLonReal, maxLonReal];
     const results = await dbSelection('portal').query(sql, args);
@@ -1531,6 +1538,20 @@ const getQuestRewardTypesByName = (search) => {
     });
     return filtered;
 };
+
+const getAreaRestrictionSql = (areaRestrictions) => {
+    let areaRestrictionsSQL = '';
+    if (areaRestrictions.length !== 0) {
+        areaRestrictionsSQL = 'AND ('
+        for (let i = 0; i < areaRestrictions.length; i++) {
+            const polygon = config.map.area_polygons[areaRestrictions[i]].join();
+            areaRestrictionsSQL += `ST_CONTAINS(ST_GEOMFROMTEXT("POLYGON((${polygon}))"), POINT(lon, lat))`
+            if (areaRestrictions.length - i > 1) areaRestrictionsSQL += ' OR ';
+        }
+        areaRestrictionsSQL += ')';
+    }
+    return areaRestrictionsSQL;
+}
 
 class Ring {
     constructor(lat, lon, radius) {

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1542,10 +1542,10 @@ const getQuestRewardTypesByName = (search) => {
 const getAreaRestrictionSql = (areaRestrictions) => {
     let areaRestrictionsSQL = '';
     if (areaRestrictions.length !== 0) {
-        areaRestrictionsSQL = 'AND ('
+        areaRestrictionsSQL = 'AND (';
         for (let i = 0; i < areaRestrictions.length; i++) {
             const polygon = config.map.area_polygons[areaRestrictions[i]].join();
-            areaRestrictionsSQL += `ST_CONTAINS(ST_GEOMFROMTEXT("POLYGON((${polygon}))"), POINT(lon, lat))`
+            areaRestrictionsSQL += `ST_CONTAINS(ST_GEOMFROMTEXT("POLYGON((${polygon}))"), POINT(lon, lat))`;
             if (areaRestrictions.length - i > 1) areaRestrictionsSQL += ' OR ';
         }
         areaRestrictionsSQL += ')';

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1545,7 +1545,7 @@ const getAreaRestrictionSql = (areaRestrictions) => {
     if (areaRestrictions.length !== 0) {
         areaRestrictionsSQL = 'AND (';
         for (let i = 0; i < areaRestrictions.length; i++) {
-            const polygon = areas.polygons[areaRestrictions[i]].join();
+            const polygon = areas.polygons[areaRestrictions[i]].map(e => e.join(' ')).join();
             areaRestrictionsSQL += `ST_CONTAINS(ST_GEOMFROMTEXT("POLYGON((${polygon}))"), POINT(lon, lat))`;
             if (areaRestrictions.length - i > 1) areaRestrictionsSQL += ' OR ';
         }

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1544,7 +1544,7 @@ const getAreaRestrictionSql = (areaRestrictions) => {
     if (areaRestrictions.length !== 0) {
         areaRestrictionsSQL = 'AND (';
         for (let i = 0; i < areaRestrictions.length; i++) {
-            const polygon = config.map.area_polygons[areaRestrictions[i]].join();
+            const polygon = config.map.areaPolygons[areaRestrictions[i]].join();
             areaRestrictionsSQL += `ST_CONTAINS(ST_GEOMFROMTEXT("POLYGON((${polygon}))"), POINT(lon, lat))`;
             if (areaRestrictions.length - i > 1) areaRestrictionsSQL += ' OR ';
         }

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -7,6 +7,7 @@ const sanitizer = require('sanitizer');
 const requireFromString = require('require-from-string');
 
 const config = require('../services/config.js');
+const areas = require('../services/areas.js');
 const MySQLConnector = require('../services/mysql.js');
 
 const db = new MySQLConnector(config.db.scanner);
@@ -1544,7 +1545,7 @@ const getAreaRestrictionSql = (areaRestrictions) => {
     if (areaRestrictions.length !== 0) {
         areaRestrictionsSQL = 'AND (';
         for (let i = 0; i < areaRestrictions.length; i++) {
-            const polygon = config.map.areaPolygons[areaRestrictions[i]].join();
+            const polygon = areas.polygons[areaRestrictions[i]].join();
             areaRestrictionsSQL += `ST_CONTAINS(ST_GEOMFROMTEXT("POLYGON((${polygon}))"), POINT(lon, lat))`;
             if (areaRestrictions.length - i > 1) areaRestrictionsSQL += ' OR ';
         }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -335,7 +335,7 @@ const getData = async (perms, filter) => {
     const permShowWeather = perms ? perms.weather !== false : true;
     const permShowNests = perms ? perms.nests !== false : true;
     const permShowPortals = perms ? perms.portals !== false : true;
-    const permAreaRestrictions = perms ? perms.area_restrictions : [];
+    const permAreaRestrictions = perms ? perms.areaRestrictions : [];
 
     let data = {};
     if ((permShowGyms && showGyms) || (permShowRaids && showRaids)) {

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -340,7 +340,7 @@ const getData = async (perms, filter) => {
     let data = {};
     if ((permShowGyms && showGyms) || (permShowRaids && showRaids)) {
         data['gyms'] = await map.getGyms(minLat, maxLat, minLon, maxLon, lastUpdate, permShowRaids && showRaids,
-         permShowGyms && showGyms, permShowGyms, raidFilterExclude, gymFilterExclude, permAreaRestrictions);
+            permShowGyms && showGyms, permShowGyms, raidFilterExclude, gymFilterExclude, permAreaRestrictions);
     }
     if (
         (permShowPokestops && showPokestops) ||
@@ -348,16 +348,16 @@ const getData = async (perms, filter) => {
         (permShowInvasions && showInvasions)
     ) {
         data['pokestops'] = await map.getPokestops(minLat, maxLat, minLon, maxLon, lastUpdate,
-        permShowPokestops && showPokestops, permShowQuests && showQuests, permShowLures, permShowInvasions && showInvasions,
-        questFilterExclude, pokestopFilterExclude, invasionFilterExclude, permAreaRestrictions);
+            permShowPokestops && showPokestops, permShowQuests && showQuests, permShowLures, permShowInvasions && showInvasions,
+            questFilterExclude, pokestopFilterExclude, invasionFilterExclude, permAreaRestrictions);
     }
     if (permShowPokemon && showPokemon) {
         data['pokemon'] = await map.getPokemon(minLat, maxLat, minLon, maxLon, permShowPVP, permShowIV, lastUpdate,
-        pokemonFilterExclude, pokemonFilterIV, permAreaRestrictions);
+            pokemonFilterExclude, pokemonFilterIV, permAreaRestrictions);
     }
     if (permShowSpawnpoints && showSpawnpoints) {
         data['spawnpoints'] = await map.getSpawnpoints(minLat, maxLat, minLon, maxLon, lastUpdate,
-        spawnpointFilterExclude, permAreaRestrictions);
+            spawnpointFilterExclude, permAreaRestrictions);
     }
     if (permShowDevices && showActiveDevices) {
         data['active_devices'] = await map.getDevices(deviceFilterExclude);

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -335,24 +335,29 @@ const getData = async (perms, filter) => {
     const permShowWeather = perms ? perms.weather !== false : true;
     const permShowNests = perms ? perms.nests !== false : true;
     const permShowPortals = perms ? perms.portals !== false : true;
+    const permAreaRestrictions = perms ? perms.area_restrictions : [];
 
     let data = {};
     if ((permShowGyms && showGyms) || (permShowRaids && showRaids)) {
-        data['gyms'] = await map.getGyms(minLat, maxLat, minLon, maxLon, lastUpdate,
-            permShowRaids && showRaids, permShowGyms && showGyms, permShowGyms, raidFilterExclude, gymFilterExclude);
+        data['gyms'] = await map.getGyms(minLat, maxLat, minLon, maxLon, lastUpdate, permShowRaids && showRaids,
+         permShowGyms && showGyms, permShowGyms, raidFilterExclude, gymFilterExclude, permAreaRestrictions);
     }
     if (
         (permShowPokestops && showPokestops) ||
         (permShowQuests && showQuests) ||
         (permShowInvasions && showInvasions)
     ) {
-        data['pokestops'] = await map.getPokestops(minLat, maxLat, minLon, maxLon, lastUpdate, permShowPokestops && showPokestops, permShowQuests && showQuests, permShowLures, permShowInvasions && showInvasions, questFilterExclude, pokestopFilterExclude, invasionFilterExclude);
+        data['pokestops'] = await map.getPokestops(minLat, maxLat, minLon, maxLon, lastUpdate,
+        permShowPokestops && showPokestops, permShowQuests && showQuests, permShowLures, permShowInvasions && showInvasions,
+        questFilterExclude, pokestopFilterExclude, invasionFilterExclude, permAreaRestrictions);
     }
     if (permShowPokemon && showPokemon) {
-        data['pokemon'] = await map.getPokemon(minLat, maxLat, minLon, maxLon, permShowPVP, permShowIV, lastUpdate, pokemonFilterExclude, pokemonFilterIV);
+        data['pokemon'] = await map.getPokemon(minLat, maxLat, minLon, maxLon, permShowPVP, permShowIV, lastUpdate,
+        pokemonFilterExclude, pokemonFilterIV, permAreaRestrictions);
     }
     if (permShowSpawnpoints && showSpawnpoints) {
-        data['spawnpoints'] = await map.getSpawnpoints(minLat, maxLat, minLon, maxLon, lastUpdate, spawnpointFilterExclude);
+        data['spawnpoints'] = await map.getSpawnpoints(minLat, maxLat, minLon, maxLon, lastUpdate,
+        spawnpointFilterExclude, permAreaRestrictions);
     }
     if (permShowDevices && showActiveDevices) {
         data['active_devices'] = await map.getDevices(deviceFilterExclude);
@@ -372,10 +377,10 @@ const getData = async (perms, filter) => {
         data['weather'] = await map.getWeather(minLat, maxLat, minLon, maxLon, lastUpdate, weatherFilterExclude);
     }
     if (permShowNests && showNests) {
-        data['nests'] = await map.getNests(minLat, maxLat, minLon, maxLon, nestFilterExclude);
+        data['nests'] = await map.getNests(minLat, maxLat, minLon, maxLon, nestFilterExclude, permAreaRestrictions);
     }
     if (permShowPortals && showPortals) {
-        data['portals'] = await map.getPortals(minLat, maxLat, minLon, maxLon, portalFilterExclude);
+        data['portals'] = await map.getPortals(minLat, maxLat, minLon, maxLon, portalFilterExclude, permAreaRestrictions);
     }
 
     if (permViewMap && showPokemonFilter) {

--- a/src/services/areas.js
+++ b/src/services/areas.js
@@ -6,15 +6,17 @@ const config = require('../services/config.js');
 
 const loadAreas = () => {
     let areas = {};
+    let showWarning = false;
 
     const areasFilePath = path.resolve(__dirname, '../../static/custom/areas.json');
     try {
         const data = fs.readFileSync(areasFilePath, 'utf8');
         areas = JSON.parse(data);
     } catch (err) {
-        if (Object.keys(config.discord.areaRestrictions).length !== 0) {
-            console.warn('[Area Restrictions] Disabled - `areas.json` file is missing or broken.');
+        for (const role of Object.values(config.discord.areaRestrictions)) {
+            if (role['roles'].length !== 0) showWarning = true;
         }
+        if (showWarning) console.warn('[Area Restrictions] Disabled - `areas.json` file is missing or broken.');
     }
     return areas;
 };

--- a/src/services/areas.js
+++ b/src/services/areas.js
@@ -9,11 +9,11 @@ const loadAreas = () => {
 
     const areasFilePath = path.resolve(__dirname, '../../static/custom/areas.json');
     try {
-        const data = fs.readFileSync(areasFilePath, 'utf8')
+        const data = fs.readFileSync(areasFilePath, 'utf8');
         areas = JSON.parse(data);
     } catch (err) {
         if (Object.keys(config.discord.areaRestrictions).length !== 0) {
-            console.warn('[Area Restrictions] Disabled - `areas.json` file is missing or broken.')
+            console.warn('[Area Restrictions] Disabled - `areas.json` file is missing or broken.');
         }
     }
     return areas;
@@ -27,11 +27,11 @@ const parseAreas = (areasObj) => {
 
     for (const feature of areasObj.features) {
         // TODO: MultiPolygon support?
-        if (feature.geometry.type == "Polygon" && feature.properties.name) {
+        if (feature.geometry.type == 'Polygon' && feature.properties.name) {
             polygons[feature.properties.name] = [];
             for (const polygonCoordinates of feature.geometry.coordinates) polygons[feature.properties.name].push(...polygonCoordinates);
         }
-    };
+    }
     names = Object.keys(polygons);
     return { names, polygons };
 };

--- a/src/services/areas.js
+++ b/src/services/areas.js
@@ -25,7 +25,7 @@ const parseAreas = async (areasObj) => {
         // TODO: MultiPolygon support?
         if (feature.geometry.type == "Polygon" && feature.properties.name) {
             polygons[feature.properties.name] = [];
-            for (const polygon_coordinates of feature.geometry.coordinates) polygons[feature.properties.name].push(...polygon_coordinates);
+            for (const polygonCoordinates of feature.geometry.coordinates) polygons[feature.properties.name].push(...polygonCoordinates);
         }
     };
     return { Object.keys(polygons), polygons };

--- a/src/services/areas.js
+++ b/src/services/areas.js
@@ -4,22 +4,26 @@ const fs = require('fs');
 const path = require('path');
 const config = require('../services/config.js');
 
-const loadAreas = async () => {
+const loadAreas = () => {
     let areas = {};
 
-    const areasFilePath = path.resolve('../../static/custom/areas.json');
-    fs.readFile(areasFilePath, (err, data) => {
-        if (err && config.discord.areaRestrictions) {
-            console.warn('Area Restrictions Skipped - `config.discord.areaRestrictions` is not empty but `areas.json` file is missing.')
-            return areas;
+    const areasFilePath = path.resolve(__dirname, '../../static/custom/areas.json');
+    try {
+        const data = fs.readFileSync(areasFilePath, 'utf8')
+        areas = JSON.parse(data);
+    } catch (err) {
+        if (Object.keys(config.discord.areaRestrictions).length !== 0) {
+            console.warn('[Area Restrictions] Disabled - `areas.json` file is missing or broken.')
         }
-        else if (!err) areas = JSON.parse(data);  // TODO: catch errors
-    });
+    }
     return areas;
 };
 
-const parseAreas = async (areasObj) => {
+const parseAreas = (areasObj) => {
+    let names = {};
     let polygons = {};
+
+    if (Object.keys(areasObj).length === 0) return { names, polygons };
 
     for (const feature of areasObj.features) {
         // TODO: MultiPolygon support?
@@ -28,11 +32,12 @@ const parseAreas = async (areasObj) => {
             for (const polygonCoordinates of feature.geometry.coordinates) polygons[feature.properties.name].push(...polygonCoordinates);
         }
     };
-    return { Object.keys(polygons), polygons };
+    names = Object.keys(polygons);
+    return { names, polygons };
 };
 
-const raw = await loadAreas();  // areas.json object in unchanged form
-const { names, polygons } = await parseAreas(raw);
+const raw = loadAreas();
+const { names, polygons } = parseAreas(raw);
 
 module.exports = {
     raw,

--- a/src/services/areas.js
+++ b/src/services/areas.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const config = require('../services/config.js');
+
+const loadAreas = async () => {
+    let areas = {};
+
+    const areasFilePath = path.resolve('../../static/custom/areas.json');
+    fs.readFile(areasFilePath, (err, data) => {
+        if (err && config.discord.areaRestrictions) {
+            console.warn('Area Restrictions Skipped - `config.discord.areaRestrictions` is not empty but `areas.json` file is missing.')
+            return areas;
+        }
+        else if (!err) areas = JSON.parse(data);  // TODO: catch errors
+    });
+    return areas;
+};
+
+const parseAreas = async (areasObj) => {
+    let polygons = {};
+
+    for (const feature of areasObj.features) {
+        // TODO: MultiPolygon support?
+        if (feature.geometry.type == "Polygon" && feature.properties.name) {
+            polygons[feature.properties.name] = [];
+            for (const polygon_coordinates of feature.geometry.coordinates) polygons[feature.properties.name].push(...polygon_coordinates);
+        }
+    };
+    return { Object.keys(polygons), polygons };
+};
+
+const raw = await loadAreas();  // areas.json object in unchanged form
+const { names, polygons } = await parseAreas(raw);
+
+module.exports = {
+    raw,
+    names,
+    polygons
+};

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -93,7 +93,7 @@ class DiscordClient {
             scanAreas: false,
             weather: false,
             devices: false,
-            area_restrictions: []
+            areaRestrictions: []
         };
         const [guilds, guildsFull] = await this.getGuilds();
         if (config.discord.allowedUsers.includes(user.id)) {
@@ -146,14 +146,14 @@ class DiscordClient {
                     if (configItem.roles.includes(userRoles[k])) {
                         perms[key] = true;
                     }
-                    // Check if user role is defined inside area_restrictions
-                    if (userRoles[k] in config.discord.area_restrictions) {
+                    // Check if user role is defined inside areaRestrictions
+                    if (userRoles[k] in config.discord.areaRestrictions) {
                         // Check if there's empty list for any of user roles, if so we disable restrictions
-                        if (config.discord.area_restrictions[userRoles[k]].length === 0) overwriteAreaRestrictions = true;
+                        if (config.discord.areaRestrictions[userRoles[k]].length === 0) overwriteAreaRestrictions = true;
                         else if (!overwriteAreaRestrictions) {
-                            for (const area_name of config.discord.area_restrictions[userRoles[k]]) {
-                                if (area_name in config.map.area_polygons) {
-                                    perms.area_restrictions.push(area_name);
+                            for (const areaName of config.discord.areaRestrictions[userRoles[k]]) {
+                                if (areaName in config.map.areaPolygons) {
+                                    perms.areaRestrictions.push(areaName);
                                 }
                             }
                         }
@@ -163,7 +163,7 @@ class DiscordClient {
         }
 
         // If any of user roles have no restrictions we are allowing all
-        if (overwriteAreaRestrictions && perms.area_restrictions) perms.area_restrictions = [];
+        if (overwriteAreaRestrictions && perms.areaRestrictions) perms.areaRestrictions = [];
 
         return perms;
     }

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -152,7 +152,7 @@ class DiscordClient {
             // Check once if user role is defined inside areaRestrictions
             for (let k = 0; k < userRoles.length; k++) {
                 for (const role of Object.values(config.discord.areaRestrictions)) {
-                    if (userRoles[k] in role['roles']) {
+                    if (role['roles'].includes(userRoles[k])) {
                         // Check if there's empty list for any of user roles, if so we disable restrictions
                         if (role['areas'].length === 0) {
                             overwriteAreaRestrictions = true;

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -151,14 +151,16 @@ class DiscordClient {
             }
             // Check once if user role is defined inside areaRestrictions
             for (let k = 0; k < userRoles.length; k++) {
-                if (userRoles[k] in config.discord.areaRestrictions) {
-                    // Check if there's empty list for any of user roles, if so we disable restrictions
-                    if (config.discord.areaRestrictions[userRoles[k]].length === 0) {
-                        overwriteAreaRestrictions = true;
-                    } else if (!overwriteAreaRestrictions) {
-                        for (const areaName of config.discord.areaRestrictions[userRoles[k]]) {
-                            if (areas.names.includes(areaName)) {
-                                perms.areaRestrictions.push(areaName);
+                for (const role of Object.values(config.discord.areaRestrictions)) {
+                    if (userRoles[k] in role['roles']) {
+                        // Check if there's empty list for any of user roles, if so we disable restrictions
+                        if (role['areas'].length === 0) {
+                            overwriteAreaRestrictions = true;
+                        } else if (!overwriteAreaRestrictions) {
+                            for (const areaName of role['areas']) {
+                                if (areas.names.includes(areaName)) {
+                                    perms.areaRestrictions.push(areaName);
+                                }
                             }
                         }
                     }

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -105,7 +105,6 @@ class DiscordClient {
 
         let blocked = false;
         let overwriteAreaRestrictions = false;
-        let areasChecked = false;
 
         for (let i = 0; i < config.discord.blockedGuilds.length; i++) {
             const guildId = config.discord.blockedGuilds[i];

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -153,8 +153,9 @@ class DiscordClient {
             for (let k = 0; k < userRoles.length; k++) {
                 if (userRoles[k] in config.discord.areaRestrictions) {
                     // Check if there's empty list for any of user roles, if so we disable restrictions
-                    if (config.discord.areaRestrictions[userRoles[k]].length === 0) overwriteAreaRestrictions = true;
-                    else if (!overwriteAreaRestrictions) {
+                    if (config.discord.areaRestrictions[userRoles[k]].length === 0) {
+                        overwriteAreaRestrictions = true;
+                    } else if (!overwriteAreaRestrictions) {
                         for (const areaName of config.discord.areaRestrictions[userRoles[k]]) {
                             if (areas.names.includes(areaName)) {
                                 perms.areaRestrictions.push(areaName);

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -149,9 +149,7 @@ class DiscordClient {
                     // Check if user role is defined inside area_restrictions
                     if (userRoles[k] in config.discord.area_restrictions) {
                         // Check if there's empty list for any of user roles, if so we disable restrictions
-                        if (config.discord.area_restrictions[userRoles[k]].length === 0) {
-                            overwriteAreaRestrictions = true;
-                        }
+                        if (config.discord.area_restrictions[userRoles[k]].length === 0) overwriteAreaRestrictions = true;
                         else if (!overwriteAreaRestrictions) {
                             for (const area_name of config.discord.area_restrictions[userRoles[k]]) {
                                 if (area_name in config.map.area_polygons) {
@@ -165,9 +163,7 @@ class DiscordClient {
         }
 
         // If any of user roles have no restrictions we are allowing all
-        if (overwriteAreaRestrictions && perms.area_restrictions) {
-            perms.area_restrictions = [];
-        }
+        if (overwriteAreaRestrictions && perms.area_restrictions) perms.area_restrictions = [];
 
         return perms;
     }

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -105,6 +105,7 @@ class DiscordClient {
 
         let blocked = false;
         let overwriteAreaRestrictions = false;
+        let areasChecked = false;
 
         for (let i = 0; i < config.discord.blockedGuilds.length; i++) {
             const guildId = config.discord.blockedGuilds[i];
@@ -147,17 +148,18 @@ class DiscordClient {
                     if (configItem.roles.includes(userRoles[k])) {
                         perms[key] = true;
                     }
-                    // Check if user role is defined inside areaRestrictions
-                    if (userRoles[k] in config.discord.areaRestrictions) {
+                    // Check once if user role is defined inside areaRestrictions
+                    if (!areasChecked && userRoles[k] in config.discord.areaRestrictions) {
                         // Check if there's empty list for any of user roles, if so we disable restrictions
                         if (config.discord.areaRestrictions[userRoles[k]].length === 0) overwriteAreaRestrictions = true;
                         else if (!overwriteAreaRestrictions) {
                             for (const areaName of config.discord.areaRestrictions[userRoles[k]]) {
-                                if (areaName in areas.names) {
+                                if (areas.names.includes(areaName)) {
                                     perms.areaRestrictions.push(areaName);
                                 }
                             }
                         }
+                        areasChecked = true;
                     }
                 }
             }

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const config = require('../services/config.js');
+const areas = require('../services/areas.js');
 const DiscordOauth2 = require('discord-oauth2');
 const Discord = require('discord.js');
 const fs = require('fs');
@@ -152,7 +153,7 @@ class DiscordClient {
                         if (config.discord.areaRestrictions[userRoles[k]].length === 0) overwriteAreaRestrictions = true;
                         else if (!overwriteAreaRestrictions) {
                             for (const areaName of config.discord.areaRestrictions[userRoles[k]]) {
-                                if (areaName in config.map.areaPolygons) {
+                                if (areaName in areas.names) {
                                     perms.areaRestrictions.push(areaName);
                                 }
                             }

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -149,6 +149,10 @@ class DiscordClient {
                     }
                 }
             }
+
+            // Continue if areas file is not loaded
+            if (Object.keys(areas.names).length === 0) continue;
+
             // Check once if user role is defined inside areaRestrictions
             for (let k = 0; k < userRoles.length; k++) {
                 for (const role of Object.values(config.discord.areaRestrictions)) {


### PR DESCRIPTION
Add area restrictions based on discord roles.

**Tested briefly.**

To get it working you need:
- filled [areas.json](https://github.com/WatWowMap/MapJS/blob/master/docs/configuration/geojson.md#scan-area) 
- correctly filled `discord.areaRestrictions` in `config.json`

For rexample:
```
"areaRestrictions": {
    "role1": {
        "roles": ["unrestrictedRoleId"],
        "areas": []
    },
    "role2": {
        "roles": ["restrictedRoleId1"],
        "areas": ["area1"]
    },
    "role3": {
        "roles": ["restrictedRoleId2"],
        "areas": ["area1", "area2"]
    },
    "role3": {
        "roles": ["restrictedRoleId3", "restrictedRoleId4"],
        "areas": ["area3"]
    }
}
```

- Any user with matching `roleId` and empty `areas` won't get restricted at all.
- User with role `restrictedRoleId1` will be able to see data only from `area1`.
- User with role `restrictedRoleId1` and `unrestrictedRoleId` won't get restricted at all.
- User with role `restrictedRoleId1` and `restrictedRoleId2` will be able to see data only from `area1, area2`.
- User with role `restrictedRoleId3` and `restrictedRoleId4` will be able to see data only from `area3`.