### PR TITLE
Fix roles change check

### DIFF
--- a/src/services/events/guildMemberUpdate.js
+++ b/src/services/events/guildMemberUpdate.js
@@ -8,9 +8,11 @@ module.exports = async (client, oldPresence, newPresence) => {
     const rolesAfter = newPresence.roles.cache
         .filter(x => BigInt(x.id).toString())
         .keyArray();
-    const perms = Object.values(client.config.discord.perms)
+    const perms = [...new Set(
+        Object.values(client.config.discord.perms)
         .map(x => x.roles)
-        .reduce(x => [...x]);
+        .flat()
+    )];
     const roleDiff = rolesBefore
         .filter(x => !rolesAfter.includes(x))
         .concat(rolesAfter

--- a/src/services/events/guildMemberUpdate.js
+++ b/src/services/events/guildMemberUpdate.js
@@ -10,8 +10,8 @@ module.exports = async (client, oldPresence, newPresence) => {
         .keyArray();
     const perms = [...new Set(
         Object.values(client.config.discord.perms)
-        .map(x => x.roles)
-        .flat()
+            .map(x => x.roles)
+            .flat()
     )];
     const roleDiff = rolesBefore
         .filter(x => !rolesAfter.includes(x))


### PR DESCRIPTION
Roles changes tracking is not working as intended. This should monitor all changes to any saved role we have in configuration.

I believe we should watch all roles inside `perms.*.roles`. This way we'll be able to track all related changes. Rest of code is working as intended. Old way was including only `perms.map.roles` so if we use `guild_id` here and split `roles` further we won't get correct session cleanup.

Small example
```js
const configPerms = {
    "map": {
        "enabled": true,
        "roles": ["12", "78"]
    },
    "pokemon": {
        "enabled": true,
        "roles": ["34"]
    },
    "raids": {
        "enabled": true,
        "roles": ["34"]
    },
    "gyms": {
        "enabled": true,
        "roles": ["56"]
    }
}

const perms_before = Object.values(configPerms)
    .map(x => x.roles)
    .reduce(x => [...x]);

const perms_after = [...new Set(
    Object.values(configPerms)
        .map(x => x.roles)
        .flat()
)];

perms_before
Array [ "12", "78" ]

perms_after
Array(4) [ "12", "78", "34", "56" ]
```