### PR TITLE
Minor Popup Adjustments

### DIFF
--- a/static/css/popups.css
+++ b/static/css/popups.css
@@ -66,7 +66,7 @@
 }
 
 .pokemon-despawn-timers {
-  grid-column: 1;
+  grid-column: 2;
   grid-row: 5;
   margin: auto;
   padding: 5px;
@@ -89,7 +89,7 @@
 }
 
 .pokemon-other-timers {
-  grid-column: 2;
+  grid-column: 1;
   grid-row: 5;
   margin: auto;
   padding: 5px;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -3077,7 +3077,7 @@ const getPokemonPopupContent = (pokemon) => {
   }
 
   const getIV = (pokemon) => {
-    if (pokemon.atk_iv !== null && popupDetails.pokemon.iv) {
+    if (pokemon.atk_iv !== null && pokemon.atk_iv !== undefined && popupDetails.pokemon.iv) {
       const ivColors = { 0: 'red', 66: 'orange', 82: 'yellow', 100: 'green' }
       const ivPercent = ((pokemon.atk_iv + pokemon.def_iv + pokemon.sta_iv) / .45).toFixed(2);
       let selectedColor


### PR DESCRIPTION
- Users were complaining that despawn timers felt less visible since they're on the left when all of the other "important" info is on the right, so this swaps the despawn timer with the first/last seen timers.

- Fix IVs from incorrectly calculating/displaying null values for users without IV perms